### PR TITLE
Replace logger with a Logger interface to allow for custom loggers.

### DIFF
--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"log"
+
+	rabbitmq "github.com/wagslane/go-rabbitmq"
+)
+
+// CustomLog is used in WithPublisherOptionsLogger to create a custom logger.
+type CustomLog struct{}
+
+func (c *CustomLog) Printf(fmt string, args ...interface{}) {
+	log.Printf("mylogger: "+fmt, args...)
+}
+
+func main() {
+	mylogger := &CustomLog{}
+
+	publisher, returns, err := rabbitmq.NewPublisher(
+		"amqp://guest:guest@localhost",
+		rabbitmq.WithPublisherOptionsLogger(mylogger),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = publisher.Publish(
+		[]byte("hello, world"),
+		[]string{"routing_key"},
+		rabbitmq.WithPublishOptionsContentType("application/json"),
+		rabbitmq.WithPublishOptionsMandatory,
+		rabbitmq.WithPublishOptionsPersistentDelivery,
+		rabbitmq.WithPublishOptionsExchange("events"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		for r := range returns {
+			log.Printf("message returned from server: %s", string(r.Body))
+		}
+	}()
+}

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -9,6 +9,7 @@ import (
 // CustomLog is used in WithPublisherOptionsLogger to create a custom logger.
 type CustomLog struct{}
 
+// Printf is the only method needed in the Logger interface to function properly.
 func (c *CustomLog) Printf(fmt string, args ...interface{}) {
 	log.Printf("mylogger: "+fmt, args...)
 }

--- a/logger.go
+++ b/logger.go
@@ -5,20 +5,22 @@ import (
 	"log"
 )
 
-type logger struct {
-	logging bool
+// Logger is the interface to send logs to. It can be set using
+// WithPublisherOptionsLogger() or WithConsumerOptionsLogger().
+type Logger interface {
+	Printf(string, ...interface{})
 }
 
 const loggingPrefix = "gorabbit"
 
-func (l logger) Printf(format string, v ...interface{}) {
-	if l.logging {
-		log.Printf(fmt.Sprintf("%s: %s", loggingPrefix, format), v...)
-	}
+// stdlog logs to stdout using go's default logger.
+type stdlog struct{}
+
+func (l stdlog) Printf(format string, v ...interface{}) {
+	log.Printf(fmt.Sprintf("%s: %s", loggingPrefix, format), v...)
 }
 
-func (l logger) Println(v ...interface{}) {
-	if l.logging {
-		log.Println(loggingPrefix, fmt.Sprintf("%v", v...))
-	}
-}
+// nolog does not log at all, this is the default.
+type nolog struct{}
+
+func (l nolog) Printf(format string, v ...interface{}) {}

--- a/publish.go
+++ b/publish.go
@@ -101,7 +101,7 @@ func WithPublisherOptionsLogging(options *PublisherOptions) {
 	options.Logger = &stdlog{}
 }
 
-// WithPublisherOptionLogger sets logging to a custom interface.
+// WithPublisherOptionsLogger sets logging to a custom interface.
 // Use WithPublisherOptionsLogging to just log to stdout.
 func WithPublisherOptionsLogger(log Logger) func(options *PublisherOptions) {
 	return func(options *PublisherOptions) {

--- a/publish.go
+++ b/publish.go
@@ -85,18 +85,29 @@ type Publisher struct {
 	disablePublishDueToFlow    bool
 	disablePublishDueToFlowMux *sync.RWMutex
 
-	logger logger
+	logger Logger
 }
 
 // PublisherOptions are used to describe a publisher's configuration.
 // Logging set to true will enable the consumer to print to stdout
 type PublisherOptions struct {
 	Logging bool
+	Logger  Logger
 }
 
 // WithPublisherOptionsLogging sets logging to true on the consumer options
 func WithPublisherOptionsLogging(options *PublisherOptions) {
 	options.Logging = true
+	options.Logger = &stdlog{}
+}
+
+// WithPublisherOptionLogger sets logging to a custom interface.
+// Use WithPublisherOptionsLogging to just log to stdout.
+func WithPublisherOptionsLogger(log Logger) func(options *PublisherOptions) {
+	return func(options *PublisherOptions) {
+		options.Logging = true
+		options.Logger = log
+	}
 }
 
 // NewPublisher returns a new publisher with an open channel to the cluster.
@@ -109,8 +120,11 @@ func NewPublisher(url string, optionFuncs ...func(*PublisherOptions)) (Publisher
 	for _, optionFunc := range optionFuncs {
 		optionFunc(options)
 	}
+	if options.Logger == nil {
+		options.Logger = &nolog{} // default no logging
+	}
 
-	chManager, err := newChannelManager(url, options.Logging)
+	chManager, err := newChannelManager(url, options.Logger)
 	if err != nil {
 		return Publisher{}, nil, err
 	}
@@ -120,7 +134,7 @@ func NewPublisher(url string, optionFuncs ...func(*PublisherOptions)) (Publisher
 		notifyFlowChan:             make(chan bool),
 		disablePublishDueToFlow:    false,
 		disablePublishDueToFlowMux: &sync.RWMutex{},
-		logger:                     logger{logging: options.Logging},
+		logger:                     options.Logger,
 	}
 
 	returnAMQPChan := make(chan amqp.Return)
@@ -182,13 +196,13 @@ func (publisher *Publisher) Publish(
 func (publisher *Publisher) startNotifyFlowHandler() {
 	for ok := range publisher.notifyFlowChan {
 		publisher.disablePublishDueToFlowMux.Lock()
-		publisher.logger.Println("pausing publishing due to flow request from server")
+		publisher.logger.Printf("pausing publishing due to flow request from server")
 		if ok {
 			publisher.disablePublishDueToFlow = false
 		} else {
 			publisher.disablePublishDueToFlow = true
 		}
 		publisher.disablePublishDueToFlowMux.Unlock()
-		publisher.logger.Println("resuming publishing due to flow request from server")
+		publisher.logger.Printf("resuming publishing due to flow request from server")
 	}
 }


### PR DESCRIPTION
Hey, great project! I'm using streadway/amqp a lot and this project basically takes away a lot of pain :)

In order to test this a bit I needed a custom logger so I swapped the logger struct with a Logger interface. I've also replaced some log.Println() with just log.Printf() and added some logging around Ack and Nack.

It should be backwards compatible and I even added an example.

Let me know what you think, I've only tested this in my local setup. Thank you.