### PR TITLE
Fix notify channels lifecycle for publisher

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -230,6 +230,10 @@ func (publisher *Publisher) startNotifyHandlers() {
 }
 
 func (publisher *Publisher) startNotifyFlowHandler(notifyFlowChan chan bool) {
+	publisher.disablePublishDueToFlowMux.Lock()
+	publisher.disablePublishDueToFlow = false
+	publisher.disablePublishDueToFlowMux.Unlock()
+
 	// Listeners for active=true flow control.  When true is sent to a listener,
 	// publishing should pause until false is sent to listeners.
 	for ok := range notifyFlowChan {


### PR DESCRIPTION
This fixes #28 and a couple other issues that
I found out in the publisher logic

All the changes:
 - Stop calling `close` on `NotifyClose` and `NotifyCancel` methods from the `*amqp.Channel`.
 As per the discussion in the issue #28, when we call those `Notify*` methods the `amqp.Channel`
 actually takes ownership of the channels and is responsible for closing them itself, as we can see
 in its `shutdown()` code: https://github.com/streadway/amqp/blob/master/channel.go#L119
 - Make sure we re-configure the `Notify*` channels from the `Publisher` when there is a close or
 cancel event on the `*amqp.Channel`. It wasn't even using the `notifyCancelOrClose` channel
 before, which I think meant a couple issues where happening after the first reconnection:
   - The new channel wouldn't be sending `return` nor `flow` events back to the publisher;
   - The `startNotifyCancelOrClosed` go-routine would get stuck sending to that notify channel,
    since no one was listening on the other side. This didn't mean reconnections would stop, but a
    little memory (goroutine) leak on every reconnection instead.

This attempts to fix both of those issues. I got also worried about some other goroutine leaks that
could be happening, like the `returnChan` which could actually not be listened by consumers and
leave a couple go-routines hanging. That feels especially troublesome, since if we create a 
`returnAMQPChan` and stop reading from it, the `amqp.Channel` internal loop itself could get stuck
and stop receiving new events. The best fix for that would be to make the return channel optional
though, so we don't always create and return one even for consumers that may not be interested and
so will never receive from it. Didn't want to break the API though so I left that part as is and only 
added a little buffer of 1 to the amqp return channel, but that does not really fix the problem.