### PR TITLE
Add function to add QueueArgs to consume options

### DIFF
--- a/consume_options.go
+++ b/consume_options.go
@@ -221,3 +221,10 @@ func WithConsumeOptionsConsumerExclusive(options *ConsumeOptions) {
 func WithConsumeOptionsConsumerNoWait(options *ConsumeOptions) {
 	options.ConsumerNoWait = true
 }
+
+// WithConsumeOptionsQueueArgs returns a function that sets the queue arguments
+func WithConsumeOptionsQueueArgs(args Table) func(*ConsumeOptions) {
+	return func(options *ConsumeOptions) {
+		options.QueueArgs = args
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wagslane/go-rabbitmq
+module github.com/tscheckenbach/go-rabbitmq
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tscheckenbach/go-rabbitmq
+module github.com/wagslane/go-rabbitmq
 
 go 1.16
 


### PR DESCRIPTION
I needed to add DLX and DLK as queue args to prevent "PRECONDITION_FAILED - inequivalent arg 'x-dead-letter-exchange' for queue" error