### PR TITLE
Add all amqp.Publishing options for internal PublishOptions struct

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,8 @@
 name: Tests
 
 on:
+  push:
   pull_request:
-    branches: [main]
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.4
+> 02 Nov 2021
+
+- Adjust all paths from wagslane to claranet for being able to install library
+
 ## v0.6.3
 > 02 Nov 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.6.3
+> 02 Nov 2021
+
+- Add all amqp.Publishing options to internal PublishOptions
+- Add notify on return channel for publisher
+- Add queue args to ConsumeOptions
+- Switch from streadway/amqp to official rabbitmq/amqp091-go
+- Allow consumer handler functions to Ack, NackDiscard, NackRequeue
+- Add option to skip exchange declaration for consumer

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Wrapper of streadway/amqp that provides reconnection logic and sane defaults. Hi
 
 Supported by [Qvault](https://qvault.io)
 
-[![](https://godoc.org/github.com/wagslane/go-rabbitmq?status.svg)](https://godoc.org/github.com/wagslane/go-rabbitmq)![Deploy](https://github.com/wagslane/go-rabbitmq/workflows/Tests/badge.svg)
+[![](https://godoc.org/github.com/claranet/go-rabbitmq?status.svg)](https://godoc.org/github.com/claranet/go-rabbitmq)![Deploy](https://github.com/claranet/go-rabbitmq/workflows/Tests/badge.svg)
 
 ## Motivation
 
@@ -28,7 +28,7 @@ The goal with `go-rabbitmq` is to still provide most all of the nitty-gritty fun
 Outside of a Go module:
 
 ```bash
-go get github.com/wagslane/go-rabbitmq
+go get github.com/claranet/go-rabbitmq
 ```
 
 ## 🚀 Quick Start Consumer
@@ -128,7 +128,7 @@ go func() {
 
 ## 💬 Contact
 
-[![Twitter Follow](https://img.shields.io/twitter/follow/wagslane.svg?label=Follow%20Wagslane&style=social)](https://twitter.com/intent/follow?screen_name=wagslane)
+[![Twitter Follow](https://img.shields.io/twitter/follow/claranet.svg?label=Follow%20Wagslane&style=social)](https://twitter.com/intent/follow?screen_name=claranet)
 
 Submit an issue (above in the issues tab)
 

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	rabbitmq "github.com/claranet/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 func main() {

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	rabbitmq "github.com/claranet/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 // customLogger is used in WithPublisherOptionsLogger to create a custom logger.

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	rabbitmq "github.com/claranet/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wagslane/go-rabbitmq
+module github.com/claranet/go-rabbitmq
 
 go 1.16
 


### PR DESCRIPTION
This enables the possibility to fully utilise the given options for publisher by the amqp library.
Code is tested, formatted and linted with the given Makefile.