### PR TITLE
Add Action.NoAction to disable implicit acknowledgement

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -14,8 +14,12 @@ type Action int
 type Handler func(d Delivery) (action Action)
 
 const (
+	// NoAction skip acknowledgement for this msg.
+	// Note: Acknowledgement can be performed later by calling an appropriate rabbitmq.Delivery
+	// Ack, Nack or Reject method.
+	NoAction Action = iota - 1
 	// Ack default ack this msg after you have successfully processed this delivery.
-	Ack Action = iota
+	Ack
 	// NackDiscard the message will be dropped or delivered to a server configured dead-letter queue.
 	NackDiscard
 	// NackRequeue deliver this message to a different consumer.


### PR DESCRIPTION
With this PR I am expanding the `Action` set with the `NoAction` value. 

Acknowledgements are either set to be `autoack` or are performed after each message processed. Returning from a handler `Action.NoAction` a user is able to issue an acknowledgement some later time manually by calling `Delivery.Ack`, `Delivery.Nack` or `Delivery.Reject` methods. This enables to implement batch processing where the `Delivery.Ack` and the negative counterpart is called with `multi:true`.
I have verified that this approach allows to implement batch processing:
```go
func handler(d rabbitmq.Delivery) rabbitmq.Action {
	batch = append(batch, d)
	if len(batch) == 5 {
		err := batchProcessor.Process(batch)
		if err != nil {
			d.Nack(true, false)
		} else {
			d.Ack(true)
		}
		batch = nil
	}

	return rabbitmq.NoAction
}
```

