### PR TITLE
runs consumer reconnection by any rabbit error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The goal with `go-rabbitmq` is to still provide most all of the nitty-gritty fun
 Inside a Go module:
 
 ```bash
-go get github.com/wagslane/go-rabbitmq
+go get github.com/fortyanov/go-rabbitmq
 ```
 
 ## 🚀 Quick Start Consumer

--- a/channel.go
+++ b/channel.go
@@ -59,8 +59,7 @@ func (chManager *channelManager) startNotifyCancelOrClosed() {
 
 	select {
 	case err := <-notifyCloseChan:
-		// If the connection close is triggered by the Server, a reconnection takes place
-		if err != nil && err.Server {
+		if err != nil {
 			chManager.logger.Printf("attempting to reconnect to amqp server after close")
 			chManager.reconnectWithBackoff()
 			chManager.logger.Printf("successfully reconnected to amqp server after close")

--- a/channel.go
+++ b/channel.go
@@ -76,11 +76,9 @@ func (chManager *channelManager) startNotifyCancelOrClosed() {
 // reconnectWithBackoff continuously attempts to reconnect with an
 // exponential backoff strategy
 func (chManager *channelManager) reconnectWithBackoff() {
-	backoffTime := time.Second
 	for {
-		chManager.logger.Printf("waiting %s seconds to attempt to reconnect to amqp server", backoffTime)
-		time.Sleep(backoffTime)
-		backoffTime *= 2
+		chManager.logger.Printf("waiting 5 seconds to attempt to reconnect to amqp server")
+		time.Sleep(5 * time.Second)
 		err := chManager.reconnect()
 		if err != nil {
 			chManager.logger.Printf("error reconnecting to amqp server: %v", err)

--- a/consume.go
+++ b/consume.go
@@ -153,11 +153,9 @@ func (consumer Consumer) startGoroutinesWithRetries(
 	routingKeys []string,
 	consumeOptions ConsumeOptions,
 ) {
-	backoffTime := time.Second
 	for {
-		consumer.logger.Printf("waiting %s seconds to attempt to start consumer goroutines", backoffTime)
-		time.Sleep(backoffTime)
-		backoffTime *= 2
+		consumer.logger.Printf("waiting 5 seconds to attempt to start consumer goroutines")
+		time.Sleep(5 * time.Second)
 		err := consumer.startGoroutines(
 			handler,
 			queue,

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	rabbitmq "github.com/fortyanov/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 var consumerName = "example"

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	rabbitmq "github.com/fortyanov/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 // customLogger is used in WithPublisherOptionsLogger to create a custom logger.

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -8,8 +8,8 @@ import (
 	"syscall"
 	"time"
 
+	rabbitmq "github.com/fortyanov/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wagslane/go-rabbitmq
+module github.com/fortyanov/go-rabbitmq
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/rabbitmq/amqp091-go v0.0.0-20210823000215-c428a6150891 h1:13nv5f/LNJxNpvpYm/u0NqrlFebon342f9Xu9GpklKc=
-github.com/rabbitmq/amqp091-go v0.0.0-20210823000215-c428a6150891/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rabbitmq/amqp091-go v1.3.0 h1:A/QuHiNw7LMCJsxx9iZn5lrIz6OrhIn7Dfk5/1YatWM=
 github.com/rabbitmq/amqp091-go v1.3.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=


### PR DESCRIPTION
I think that may be good idea to run consumer reconnection by any error because there is situations when internet connection breaks and consumer not working anymore. It might be worth adding some field for set up this behavior to the consumer settings fields, but I'm not sure.