### PR TITLE
runs consumer reconnection by any rabbit error

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -59,8 +59,7 @@ func (chManager *channelManager) startNotifyCancelOrClosed() {
 
 	select {
 	case err := <-notifyCloseChan:
-		// If the connection close is triggered by the Server, a reconnection takes place
-		if err != nil && err.Server {
+		if err != nil {
 			chManager.logger.Printf("attempting to reconnect to amqp server after close")
 			chManager.reconnectWithBackoff()
 			chManager.logger.Printf("successfully reconnected to amqp server after close")

--- a/channel.go
+++ b/channel.go
@@ -68,7 +68,7 @@ func (chManager *channelManager) startNotifyCancelOrClosed() {
 			chManager.notifyCancelOrClose <- err
 		} else if err != nil && err.Reason == "EOF" {
 			chManager.logger.Printf("attempting to reconnect to amqp server after eof")
-			chManager.reconnectWithBackoff()
+			chManager.reconnectLoop()
 			chManager.logger.Printf("successfully reconnected to amqp server after eof")
 			chManager.notifyCancelOrClose <- err
 		} else if err != nil {


### PR DESCRIPTION
I think that may be good idea to run consumer reconnection by any error because there is situations when internet connection to rabbit service breaks for a while and after that consumer not working anymore. It might be worth adding some field for set up this behavior to the consumer settings fields, but I'm not sure.