### PR TITLE
Error handling on channel closing while reconnecting.

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -103,13 +103,12 @@ func (chManager *channelManager) reconnect() error {
 		return err
 	}
 
-	err = chManager.channel.Close()
-	if err != nil {
-		return err
+	if err = chManager.channel.Close(); err != nil {
+		chManager.logger.Warnf("error closing channel while reconnecting: %v", err)
 	}
-	err = chManager.connection.Close()
-	if err != nil {
-		return err
+
+	if err = chManager.connection.Close(); err != nil {
+		chManager.logger.Warnf("error closing connection while reconnecting: %v", err)
 	}
 
 	chManager.connection = newConn

--- a/channel.go
+++ b/channel.go
@@ -103,8 +103,14 @@ func (chManager *channelManager) reconnect() error {
 		return err
 	}
 
-	chManager.channel.Close()
-	chManager.connection.Close()
+	err = chManager.channel.Close()
+	if err != nil {
+		return err
+	}
+	err = chManager.connection.Close()
+	if err != nil {
+		return err
+	}
 
 	chManager.connection = newConn
 	chManager.channel = newChannel


### PR DESCRIPTION
Hello, probably here error handling missed.

It looks like even if it needs to be ignored here it would be good to add some logging in case of error. It is the wrong behavior of Close and the developer needs to know that something not good happened.