### PR TITLE
close channel once the consumer is stopped

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -108,6 +108,13 @@ func (consumer *Consumer) Close() {
 	consumer.isClosedMux.Lock()
 	defer consumer.isClosedMux.Unlock()
 	consumer.isClosed = true
+	// close the channel so that rabbitmq server knows that the
+	// consumer has been stopped.
+	err := consumer.chanManager.Close()
+	if err != nil {
+		consumer.options.Logger.Warnf("error while closing the channel: %v", err)
+	}
+
 	consumer.options.Logger.Infof("closing consumer...")
 	go func() {
 		consumer.closeConnectionToManagerCh <- struct{}{}


### PR DESCRIPTION
If a consumer is listening on an Exclusive queue, It won't be stopped because the channel is still in use. Close the channel once the consumer is stopped so that the temporary queue can be cleared by the Rabbitmq Server.

Signed-off-by: Aaqa Ishtyaq <aaqa@hackerrank.com>