### PR TITLE
fix: Add manual action to consumer return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Wrapper of [rabbitmq/amqp091-go](https://github.com/rabbitmq/amqp091-go) that pr
 
 Supported by [Boot.dev](https://boot.dev)
 
-[![](https://godoc.org/github.com/wagslane/go-rabbitmq?status.svg)](https://godoc.org/github.com/wagslane/go-rabbitmq)![Deploy](https://github.com/wagslane/go-rabbitmq/workflows/Tests/badge.svg)
+[![](https://godoc.org/github.com/rudrasecure/go-rabbitmq?status.svg)](https://godoc.org/github.com/rudrasecure/go-rabbitmq)![Deploy](https://github.com/rudrasecure/go-rabbitmq/workflows/Tests/badge.svg)
 
 ## Motivation
 
@@ -25,7 +25,7 @@ The goal with `go-rabbitmq` is to provide *most* (but not all) of the nitty-grit
 Inside a Go module:
 
 ```bash
-go get github.com/wagslane/go-rabbitmq
+go get github.com/rudrasecure/go-rabbitmq
 ```
 
 ## 🚀 Quick Start Consumer

--- a/connection.go
+++ b/connection.go
@@ -2,7 +2,7 @@ package rabbitmq
 
 import (
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
+	"github.com/rudrasecure/go-rabbitmq/internal/connectionmanager"
 )
 
 // Conn manages the connection to a rabbit cluster

--- a/consume.go
+++ b/consume.go
@@ -22,6 +22,8 @@ const (
 	NackDiscard
 	// NackRequeue deliver this message to a different consumer.
 	NackRequeue
+	// Message acknowledgement is left to the end user
+	Manual
 )
 
 // Consumer allows you to create and connect to queues for data consumption.

--- a/consume.go
+++ b/consume.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
+	"github.com/rudrasecure/go-rabbitmq/internal/channelmanager"
 )
 
 // Action is an action that occurs after processed this delivery

--- a/consumer_options.go
+++ b/consumer_options.go
@@ -2,7 +2,7 @@ package rabbitmq
 
 import (
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/rudrasecure/go-rabbitmq/internal/logger"
 )
 
 // getDefaultConsumerOptions describes the options that will be used when a value isn't provided

--- a/declare.go
+++ b/declare.go
@@ -1,7 +1,7 @@
 package rabbitmq
 
 import (
-	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
+	"github.com/rudrasecure/go-rabbitmq/internal/channelmanager"
 )
 
 func declareQueue(chanManager *channelmanager.ChannelManager, options QueueOptions) error {

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	rabbitmq "github.com/rudrasecure/go-rabbitmq"
 )
 
 func main() {

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	rabbitmq "github.com/rudrasecure/go-rabbitmq"
 )
 
 // errorLogger is used in WithPublisherOptionsLogger to create a custom logger

--- a/examples/multiconsumer/main.go
+++ b/examples/multiconsumer/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	rabbitmq "github.com/rudrasecure/go-rabbitmq"
 )
 
 func main() {

--- a/examples/multipublisher/main.go
+++ b/examples/multipublisher/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	rabbitmq "github.com/rudrasecure/go-rabbitmq"
 )
 
 func main() {

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	rabbitmq "github.com/rudrasecure/go-rabbitmq"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wagslane/go-rabbitmq
+module github.com/rudrasecure/go-rabbitmq
 
 go 1.17
 

--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
-	"github.com/wagslane/go-rabbitmq/internal/dispatcher"
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/rudrasecure/go-rabbitmq/internal/connectionmanager"
+	"github.com/rudrasecure/go-rabbitmq/internal/dispatcher"
+	"github.com/rudrasecure/go-rabbitmq/internal/logger"
 )
 
 // ChannelManager -

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/dispatcher"
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/rudrasecure/go-rabbitmq/internal/dispatcher"
+	"github.com/rudrasecure/go-rabbitmq/internal/logger"
 )
 
 // ConnectionManager -

--- a/logger.go
+++ b/logger.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/rudrasecure/go-rabbitmq/internal/logger"
 )
 
 // Logger is describes a logging structure. It can be set using

--- a/publish.go
+++ b/publish.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
-	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
+	"github.com/rudrasecure/go-rabbitmq/internal/channelmanager"
+	"github.com/rudrasecure/go-rabbitmq/internal/connectionmanager"
 )
 
 // DeliveryMode. Transient means higher throughput but messages will not be


### PR DESCRIPTION
I would want to spin up goroutines to do some other processing on the message and use the amqp.Delivery object to send acknowledgements later from the routine. Currently the consumer handler expects a compulsory type which doesn't let us do any processing from a routine.