### PR TITLE
update: Add manual action to consumer handler & expose function for Publishing with deferred confirmation

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -22,6 +22,8 @@ const (
 	NackDiscard
 	// NackRequeue deliver this message to a different consumer.
 	NackRequeue
+	// Message acknowledgement is left to the user using the msg.Ack() method
+	Manual
 )
 
 // Consumer allows you to create and connect to queues for data consumption.

--- a/internal/channelmanager/safe_wraps.go
+++ b/internal/channelmanager/safe_wraps.go
@@ -171,6 +171,22 @@ func (chanManager *ChannelManager) PublishWithContextSafe(
 	)
 }
 
+func (chanManager *ChannelManager) PublishWithDeferredConfirmWithContextSafe(
+	ctx context.Context, exchange string, key string, mandatory bool, immediate bool, msg amqp.Publishing,
+) (*amqp.DeferredConfirmation, error) {
+	chanManager.channelMux.RLock()
+	defer chanManager.channelMux.RUnlock()
+
+	return chanManager.channel.PublishWithDeferredConfirmWithContext(
+		ctx,
+		exchange,
+		key,
+		mandatory,
+		immediate,
+		msg,
+	)
+}
+
 // NotifyReturnSafe safely wraps the (*amqp.Channel).NotifyReturn method
 func (chanManager *ChannelManager) NotifyReturnSafe(
 	c chan amqp.Return,


### PR DESCRIPTION
I would want to spin up goroutines to do some other processing on the message and use the amqp.Delivery object to send acknowledgements later from the routine. Currently the consumer handler expects a compulsory type which doesn't let us do any processing from a routine.