### PR TITLE
close publisher properly to prevent resource leaks

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -191,6 +191,12 @@ func (publisher *Publisher) Publish(
 // The publisher should be discarded as it's not safe for re-use
 // Only call Close() once
 func (publisher *Publisher) Close() {
+	// close the channel so that rabbitmq server knows that the
+	// publisher has been stopped.
+	err := publisher.chanManager.Close()
+	if err != nil {
+		publisher.options.Logger.Warnf("error while closing the channel: %v", err)
+	}
 	publisher.options.Logger.Infof("closing publisher...")
 	go func() {
 		publisher.closeConnectionToManagerCh <- struct{}{}


### PR DESCRIPTION
Fix #102 