### PR TITLE
fix: fatal default log

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -17,7 +17,7 @@ type stdDebugLogger struct{}
 
 // Fatalf -
 func (l stdDebugLogger) Fatalf(format string, v ...interface{}) {
-	log.Printf(fmt.Sprintf("%s FATAL: %s", loggingPrefix, format), v...)
+	log.Fatalf(fmt.Sprintf("%s FATAL: %s", loggingPrefix, format), v...)
 }
 
 // Errorf -


### PR DESCRIPTION
The `Fatal` log level usually terminates the process https://pkg.go.dev/log#Logger.Fatal, so I think the default logger should do the same.