### PR TITLE
1. delete logger Fatal. 2. Expose the channel method

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -2,16 +2,13 @@ package rabbitmq
 
 import (
 	"errors"
+	"fmt"
 
-	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
+	"github.com/xmapst/go-rabbitmq/internal/channelmanager"
 )
 
-type Channel struct {
-	*channelmanager.ChannelManager
-}
-
 // NewChannel returns a new channel to the cluster.
-func NewChannel(conn *Conn, optionFuncs ...func(*ChannelOptions)) (*Channel, error) {
+func NewChannel(conn *Conn, optionFuncs ...func(*ChannelOptions)) (*channelmanager.ChannelManager, error) {
 	defaultOptions := getDefaultChannelOptions()
 	options := &defaultOptions
 	for _, optionFunc := range optionFuncs {
@@ -25,7 +22,10 @@ func NewChannel(conn *Conn, optionFuncs ...func(*ChannelOptions)) (*Channel, err
 	if err != nil {
 		return nil, err
 	}
-	return &Channel{
-		channel,
-	}, nil
+	err = channel.QosSafe(options.QOSPrefetch, 0, options.QOSGlobal)
+	if err != nil {
+		_ = channel.Close()
+		return nil, fmt.Errorf("declare qos failed: %w", err)
+	}
+	return channel, nil
 }

--- a/channel.go
+++ b/channel.go
@@ -1,0 +1,31 @@
+package rabbitmq
+
+import (
+	"errors"
+
+	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
+)
+
+type Channel struct {
+	*channelmanager.ChannelManager
+}
+
+// NewChannel returns a new channel to the cluster.
+func NewChannel(conn *Conn, optionFuncs ...func(*ChannelOptions)) (*Channel, error) {
+	defaultOptions := getDefaultChannelOptions()
+	options := &defaultOptions
+	for _, optionFunc := range optionFuncs {
+		optionFunc(options)
+	}
+
+	if conn.connectionManager == nil {
+		return nil, errors.New("connection manager can't be nil")
+	}
+	channel, err := channelmanager.NewChannelManager(conn.connectionManager, options.Logger, conn.connectionManager.ReconnectInterval)
+	if err != nil {
+		return nil, err
+	}
+	return &Channel{
+		channel,
+	}, nil
+}

--- a/channel_options.go
+++ b/channel_options.go
@@ -3,13 +3,17 @@ package rabbitmq
 // ChannelOptions are used to describe a channel's configuration.
 // Logger is a custom logging interface.
 type ChannelOptions struct {
-	Logger Logger
+	Logger      Logger
+	QOSPrefetch int
+	QOSGlobal   bool
 }
 
 // getDefaultChannelOptions describes the options that will be used when a value isn't provided
 func getDefaultChannelOptions() ChannelOptions {
 	return ChannelOptions{
-		Logger: stdDebugLogger{},
+		Logger:      stdDebugLogger{},
+		QOSPrefetch: 10,
+		QOSGlobal:   false,
 	}
 }
 

--- a/channel_options.go
+++ b/channel_options.go
@@ -1,0 +1,28 @@
+package rabbitmq
+
+// ChannelOptions are used to describe a channel's configuration.
+// Logger is a custom logging interface.
+type ChannelOptions struct {
+	Logger Logger
+}
+
+// getDefaultChannelOptions describes the options that will be used when a value isn't provided
+func getDefaultChannelOptions() ChannelOptions {
+	return ChannelOptions{
+		Logger: stdDebugLogger{},
+	}
+}
+
+// WithChannelOptionsLogging sets logging to true on the channel options
+// and sets the
+func WithChannelOptionsLogging(options *ChannelOptions) {
+	options.Logger = &stdDebugLogger{}
+}
+
+// WithChannelOptionsLogger sets logging to a custom interface.
+// Use WithChannelOptionsLogging to just log to stdout.
+func WithChannelOptionsLogger(log Logger) func(options *ChannelOptions) {
+	return func(options *ChannelOptions) {
+		options.Logger = log
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -2,7 +2,7 @@ package rabbitmq
 
 import (
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
+	"github.com/xmapst/go-rabbitmq/internal/connectionmanager"
 )
 
 // Conn manages the connection to a rabbit cluster

--- a/consume.go
+++ b/consume.go
@@ -94,8 +94,8 @@ func NewConsumer(
 				*options,
 			)
 			if err != nil {
-				consumer.options.Logger.Fatalf("error restarting consumer goroutines after cancel or close: %v", err)
-				consumer.options.Logger.Fatalf("consumer closing, unable to recover")
+				consumer.options.Logger.Errorf("error restarting consumer goroutines after cancel or close: %v", err)
+				consumer.options.Logger.Errorf("consumer closing, unable to recover")
 				return
 			}
 		}

--- a/consume.go
+++ b/consume.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
+	"github.com/xmapst/go-rabbitmq/internal/channelmanager"
 )
 
 // Action is an action that occurs after processed this delivery

--- a/consumer_options.go
+++ b/consumer_options.go
@@ -2,7 +2,7 @@ package rabbitmq
 
 import (
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/xmapst/go-rabbitmq/internal/logger"
 )
 
 // getDefaultConsumerOptions describes the options that will be used when a value isn't provided

--- a/declare.go
+++ b/declare.go
@@ -1,7 +1,7 @@
 package rabbitmq
 
 import (
-	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
+	"github.com/xmapst/go-rabbitmq/internal/channelmanager"
 )
 
 func declareQueue(chanManager *channelmanager.ChannelManager, options QueueOptions) error {

--- a/examples/channel/.gitignore
+++ b/examples/channel/.gitignore
@@ -1,0 +1,1 @@
+channel

--- a/examples/channel/main.go
+++ b/examples/channel/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+
+	"github.com/rabbitmq/amqp091-go"
+	"github.com/wagslane/go-rabbitmq"
+)
+
+func main() {
+	conn, err := rabbitmq.NewConn(
+		"amqp://guest:guest@localhost",
+		rabbitmq.WithConnectionOptionsLogging,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	channel, err := rabbitmq.NewChannel(conn)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer channel.Close()
+
+	_, err = channel.QueueDeclareSafe(
+		"re_my_queue", true, false, false, false,
+		amqp091.Table{
+			"x-dead-letter-exchange":    "events",
+			"x-dead-letter-routing-key": "my_routing_key",
+		})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = channel.QueueBindSafe("re_my_routing_key", "re_my_queue", "events", false, amqp091.Table{})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/channel/main.go
+++ b/examples/channel/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 
 	"github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq"
+	"github.com/xmapst/go-rabbitmq"
 )
 
 func main() {

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	"github.com/xmapst/go-rabbitmq"
 )
 
 func main() {

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"log"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	rabbitmq "github.com/xmapst/go-rabbitmq"
 )
 
 // errorLogger is used in WithPublisherOptionsLogger to create a custom logger
 // that only logs ERROR and FATAL log levels
 type errorLogger struct{}
-
-func (l errorLogger) Fatalf(format string, v ...interface{}) {
-	log.Printf("mylogger: "+format, v...)
-}
 
 func (l errorLogger) Errorf(format string, v ...interface{}) {
 	log.Printf("mylogger: "+format, v...)

--- a/examples/multiconsumer/main.go
+++ b/examples/multiconsumer/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	rabbitmq "github.com/xmapst/go-rabbitmq"
 )
 
 func main() {

--- a/examples/multipublisher/main.go
+++ b/examples/multipublisher/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	"github.com/xmapst/go-rabbitmq"
 )
 
 func main() {

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	"github.com/xmapst/go-rabbitmq"
 )
 
 func main() {

--- a/examples/publisher_confirm/main.go
+++ b/examples/publisher_confirm/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	rabbitmq "github.com/wagslane/go-rabbitmq"
+	"github.com/xmapst/go-rabbitmq"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wagslane/go-rabbitmq
+module github.com/xmapst/go-rabbitmq
 
 go 1.20
 

--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
-	"github.com/wagslane/go-rabbitmq/internal/dispatcher"
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/xmapst/go-rabbitmq/internal/connectionmanager"
+	"github.com/xmapst/go-rabbitmq/internal/dispatcher"
+	"github.com/xmapst/go-rabbitmq/internal/logger"
 )
 
 // ChannelManager -

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/dispatcher"
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/xmapst/go-rabbitmq/internal/dispatcher"
+	"github.com/xmapst/go-rabbitmq/internal/logger"
 )
 
 // ConnectionManager -

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -3,7 +3,6 @@ package logger
 // Logger is describes a logging structure. It can be set using
 // WithPublisherOptionsLogger() or WithConsumerOptionsLogger().
 type Logger interface {
-	Fatalf(string, ...interface{})
 	Errorf(string, ...interface{})
 	Warnf(string, ...interface{})
 	Infof(string, ...interface{})

--- a/logger.go
+++ b/logger.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/wagslane/go-rabbitmq/internal/logger"
+	"github.com/xmapst/go-rabbitmq/internal/logger"
 )
 
 // Logger is describes a logging structure. It can be set using

--- a/logger.go
+++ b/logger.go
@@ -15,11 +15,6 @@ const loggingPrefix = "gorabbit"
 
 type stdDebugLogger struct{}
 
-// Fatalf -
-func (l stdDebugLogger) Fatalf(format string, v ...interface{}) {
-	log.Printf(fmt.Sprintf("%s FATAL: %s", loggingPrefix, format), v...)
-}
-
 // Errorf -
 func (l stdDebugLogger) Errorf(format string, v ...interface{}) {
 	log.Printf(fmt.Sprintf("%s ERROR: %s", loggingPrefix, format), v...)

--- a/publish.go
+++ b/publish.go
@@ -109,8 +109,8 @@ func NewPublisher(conn *Conn, optionFuncs ...func(*PublisherOptions)) (*Publishe
 			publisher.options.Logger.Infof("successful publisher recovery from: %v", err)
 			err := publisher.startup()
 			if err != nil {
-				publisher.options.Logger.Fatalf("error on startup for publisher after cancel or close: %v", err)
-				publisher.options.Logger.Fatalf("publisher closing, unable to recover")
+				publisher.options.Logger.Errorf("error on startup for publisher after cancel or close: %v", err)
+				publisher.options.Logger.Errorf("publisher closing, unable to recover")
 				return
 			}
 			go publisher.startReturnHandler()

--- a/publish.go
+++ b/publish.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
-	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
+	"github.com/xmapst/go-rabbitmq/internal/channelmanager"
+	"github.com/xmapst/go-rabbitmq/internal/connectionmanager"
 )
 
 // DeliveryMode. Transient means higher throughput but messages will not be

--- a/table.go
+++ b/table.go
@@ -33,9 +33,9 @@ import amqp "github.com/rabbitmq/amqp091-go"
 type Table map[string]interface{}
 
 func tableToAMQPTable(table Table) amqp.Table {
-	new := amqp.Table{}
+	newTable := amqp.Table{}
 	for k, v := range table {
-		new[k] = v
+		newTable[k] = v
 	}
-	return new
+	return newTable
 }


### PR DESCRIPTION
1. Delete logger Fatal interface
Fatal will cause the program to terminate when using a third-party log library
2. Expose the channel method
In special occasions, you need to use the channel to perform some operations, for example: only create dead letter queues and binding relationships