### PR TITLE
Remove tracef from logger interface

### DIFF
--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -28,8 +28,6 @@ func (l errorLogger) Infof(format string, v ...interface{}) {
 func (l errorLogger) Debugf(format string, v ...interface{}) {
 }
 
-func (l errorLogger) Tracef(format string, v ...interface{}) {}
-
 func main() {
 	mylogger := &errorLogger{}
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -8,5 +8,4 @@ type Logger interface {
 	Warnf(string, ...interface{})
 	Infof(string, ...interface{})
 	Debugf(string, ...interface{})
-	Tracef(string, ...interface{})
 }

--- a/logger.go
+++ b/logger.go
@@ -39,6 +39,3 @@ func (l stdDebugLogger) Infof(format string, v ...interface{}) {
 func (l stdDebugLogger) Debugf(format string, v ...interface{}) {
 	log.Printf(fmt.Sprintf("%s DEBUG: %s", loggingPrefix, format), v...)
 }
-
-// Tracef -
-func (l stdDebugLogger) Tracef(format string, v ...interface{}) {}


### PR DESCRIPTION
The default logger interface expects `Tracef` to be implemented by any logger passed, however for people using `zap` logger we have to go through extra steps to be able to pass a sugared logger as the logger to use. Since `Tracef` is not actually used in any part of the codebase, I think it is safe to remove from the interface.