### PR TITLE
feat: added consumer.WaitForHandlers

### DIFF
--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -35,7 +36,13 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer consumer.Close()
+	defer func() {
+		consumer.Close()
+
+		// We can optionally wait for any long-running handlers to finish cleanly and avoid stopping the process
+		// while handlers are still closing files or performing actions that are vulnerable to corruption.
+		_ = consumer.WaitForHandlers(context.Background())
+	}()
 
 	// block main thread - wait for shutdown signal
 	sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
I'd like to propose adding a `WaitForHandlers` method to the consumer which waits for any running handlers to complete processing their current messages. This is because `Close` doesn't wait for the handlers to finish or queue to be drained (this makes sense).

This solves a couple of issues I've been facing:

1. Some message handling may be performing actions that need to clean up properly: file/database IO, external requests, even when idempotent may cause corruptions if the handlers are interrupted without being allowed to shutdown safely.

2. Applying a circuit breaking pattern to stop a handler from consuming new messages if they are failing frequently due to overload or dependency failures.

The code in this PR could be added to the handler method itself, but I think it may be a useful pattern that others may take advantage of so I'd like to consider including it in this library.

Happy to discuss further :)