### PR TITLE
Add cluster support via Resolver

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1,9 +1,35 @@
 package rabbitmq
 
 import (
+	"math/rand"
+
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
 )
+
+type Resolver = connectionmanager.Resolver
+
+type StaticResolver struct {
+	urls   []string
+	shuffe bool
+}
+
+func (r *StaticResolver) Resolve() ([]string, error) {
+	// TODO: move to slices.Clone when supported Go versions > 1.21
+	var urls []string
+	urls = append(urls, r.urls...)
+
+	if r.shuffe {
+		rand.Shuffle(len(urls), func(i, j int) {
+			urls[i], urls[j] = urls[j], urls[i]
+		})
+	}
+	return urls, nil
+}
+
+func NewStaticResolver(urls []string, shuffle bool) *StaticResolver {
+	return &StaticResolver{urls: urls}
+}
 
 // Conn manages the connection to a rabbit cluster
 // it is intended to be shared across publishers and consumers
@@ -22,14 +48,18 @@ type Conn struct {
 type Config amqp.Config
 
 // NewConn creates a new connection manager
-func NewConn(url string, optionFuncs ...func(*ConnectionOptions)) (*Conn, error) {
+func NewConn(url string, opts ...func(*ConnectionOptions)) (*Conn, error) {
+	return NewClusterConn(NewStaticResolver([]string{url}, false), opts...)
+}
+
+func NewClusterConn(resolver Resolver, opts ...func(*ConnectionOptions)) (*Conn, error) {
 	defaultOptions := getDefaultConnectionOptions()
 	options := &defaultOptions
-	for _, optionFunc := range optionFuncs {
-		optionFunc(options)
+	for _, optFn := range opts {
+		optFn(options)
 	}
 
-	manager, err := connectionmanager.NewConnectionManager(url, amqp.Config(options.Config), options.Logger, options.ReconnectInterval)
+	manager, err := connectionmanager.NewConnectionManager(resolver, amqp.Config(options.Config), options.Logger, options.ReconnectInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/cluster/main.go
+++ b/examples/cluster/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"log"
+
+	rabbitmq "github.com/wagslane/go-rabbitmq"
+)
+
+func main() {
+	resolver := rabbitmq.NewStaticResolver(
+		[]string{
+			"amqp://guest:guest@host1",
+			"amqp://guest:guest@host2",
+			"amqp://guest:guest@host3",
+		},
+		false, /* shuffle */
+	)
+
+	conn, err := rabbitmq.NewClusterConn(resolver)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+}

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -1,6 +1,8 @@
 package connectionmanager
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -9,10 +11,14 @@ import (
 	"github.com/wagslane/go-rabbitmq/internal/logger"
 )
 
+type Resolver interface {
+	Resolve() ([]string, error)
+}
+
 // ConnectionManager -
 type ConnectionManager struct {
 	logger               logger.Logger
-	url                  string
+	resolver             Resolver
 	connection           *amqp.Connection
 	amqpConfig           amqp.Config
 	connectionMux        *sync.RWMutex
@@ -22,15 +28,36 @@ type ConnectionManager struct {
 	dispatcher           *dispatcher.Dispatcher
 }
 
+// dial will attempt to connect to the a list of urls in the order they are
+// given.
+func dial(log logger.Logger, resolver Resolver, conf amqp.Config) (*amqp.Connection, error) {
+	urls, err := resolver.Resolve()
+	if err != nil {
+		return nil, fmt.Errorf("error resolving amqp server urls: %w", err)
+	}
+
+	var errs []error
+	for _, url := range urls {
+		conn, err := amqp.DialConfig(url, amqp.Config(conf))
+		if err == nil {
+			return conn, err
+		}
+		log.Warnf("failed to connect to amqp server %s: %v", url, err)
+		errs = append(errs, err)
+	}
+	return nil, errors.Join(errs...)
+}
+
 // NewConnectionManager creates a new connection manager
-func NewConnectionManager(url string, conf amqp.Config, log logger.Logger, reconnectInterval time.Duration) (*ConnectionManager, error) {
-	conn, err := amqp.DialConfig(url, amqp.Config(conf))
+func NewConnectionManager(resolver Resolver, conf amqp.Config, log logger.Logger, reconnectInterval time.Duration) (*ConnectionManager, error) {
+	conn, err := dial(log, resolver, amqp.Config(conf))
 	if err != nil {
 		return nil, err
 	}
+
 	connManager := ConnectionManager{
 		logger:               log,
-		url:                  url,
+		resolver:             resolver,
 		connection:           conn,
 		amqpConfig:           conf,
 		connectionMux:        &sync.RWMutex{},
@@ -125,7 +152,8 @@ func (connManager *ConnectionManager) reconnectLoop() {
 func (connManager *ConnectionManager) reconnect() error {
 	connManager.connectionMux.Lock()
 	defer connManager.connectionMux.Unlock()
-	newConn, err := amqp.DialConfig(connManager.url, amqp.Config(connManager.amqpConfig))
+
+	conn, err := dial(connManager.logger, connManager.resolver, amqp.Config(connManager.amqpConfig))
 	if err != nil {
 		return err
 	}
@@ -134,6 +162,6 @@ func (connManager *ConnectionManager) reconnect() error {
 		connManager.logger.Warnf("error closing connection while reconnecting: %v", err)
 	}
 
-	connManager.connection = newConn
+	connManager.connection = conn
 	return nil
 }


### PR DESCRIPTION
This adds support for RabbitMQ clusters to connect up to one of a number of servers.

It does this through a `Resolver` interface which has a single method called `Resolve()` which can return a list of servers.  There is a standard implementation included called `StaticResolver` that will just take a list of URLS to connect to and optionally shuffle that list.

This interface approach allows for implementers of the library to extend for service discovery or other advanced typologies.   

Fixes:  #148