### PR TITLE
fix: consumer close before run

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -131,6 +131,8 @@ func (consumer *Consumer) startGoroutines(
 	handler Handler,
 	options ConsumerOptions,
 ) error {
+	consumer.isClosedMux.Lock()
+	defer consumer.isClosedMux.Unlock()
 	err := consumer.chanManager.QosSafe(
 		options.QOSPrefetch,
 		0,


### PR DESCRIPTION
When running `consumer.Close` before the `consumer.Run` has finished, `Run` will never return.

Prevent this by also getting the `isClosedMux` lock while initialising the handler.