### PR TITLE
Consumer: close gracefully

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -122,6 +122,7 @@ func (consumer *Consumer) Run(handler Handler) error {
 // Only call once.
 func (consumer *Consumer) Close() {
 	if consumer.options.CloseGracefully {
+		consumer.options.Logger.Infof("waiting for handlers to finish...")
 		err := consumer.waitForHandlers(context.Background())
 		if err != nil {
 			consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)

--- a/consume.go
+++ b/consume.go
@@ -152,7 +152,7 @@ func (consumer *Consumer) Close() {
 // Only call once.
 func (consumer *Consumer) CloseWithContext(ctx context.Context) {
 	if consumer.options.CloseGracefully {
-		err := consumer.waitForHandlers(context.Background())
+		err := consumer.waitForHandlers(ctx)
 		if err != nil {
 			consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)
 		}

--- a/consume.go
+++ b/consume.go
@@ -114,16 +114,16 @@ func (consumer *Consumer) Run(handler Handler) error {
 }
 
 // Close cleans up resources and closes the consumer.
-// It waits for all handlers to finish before returning by default
+// It waits for handler to finish before returning by default
 // (use WithConsumerOptionsForceShutdown option to disable this behavior).
-// Use CloseWithContext to specify a context to cancel the handlers completion.
+// Use CloseWithContext to specify a context to cancel the handler completion.
 // It does not close the connection manager, just the subscription
 // to the connection manager and the consuming goroutines.
 // Only call once.
 func (consumer *Consumer) Close() {
 	if consumer.options.CloseGracefully {
-		consumer.options.Logger.Infof("waiting for handlers to finish...")
-		err := consumer.waitForHandlers(context.Background())
+		consumer.options.Logger.Infof("waiting for handler to finish...")
+		err := consumer.waitForHandlerCompletion(context.Background())
 		if err != nil {
 			consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)
 		}
@@ -151,15 +151,15 @@ func (consumer *Consumer) cleanupResources() {
 }
 
 // CloseWithContext cleans up resources and closes the consumer.
-// It waits for all handlers to finish before returning
+// It waits for handler to finish before returning
 // (use WithConsumerOptionsForceShutdown option to disable this behavior).
-// Use the context to cancel the handlers completion.
+// Use the context to cancel the handler completion.
 // CloseWithContext does not close the connection manager, just the subscription
 // to the connection manager and the consuming goroutines.
 // Only call once.
 func (consumer *Consumer) CloseWithContext(ctx context.Context) {
 	if consumer.options.CloseGracefully {
-		err := consumer.waitForHandlers(ctx)
+		err := consumer.waitForHandlerCompletion(ctx)
 		if err != nil {
 			consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)
 		}
@@ -256,7 +256,7 @@ func handlerGoroutine(consumer *Consumer, msgs <-chan amqp.Delivery, consumeOpti
 	consumer.options.Logger.Infof("rabbit consumer goroutine closed")
 }
 
-func (consumer *Consumer) waitForHandlers(ctx context.Context) error {
+func (consumer *Consumer) waitForHandlerCompletion(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	} else if ctx.Err() != nil {

--- a/consumer_options.go
+++ b/consumer_options.go
@@ -28,6 +28,7 @@ func getDefaultConsumerOptions(queueName string) ConsumerOptions {
 		},
 		ExchangeOptions: []ExchangeOptions{},
 		Concurrency:     1,
+		CloseGracefully: true,
 		Logger:          stdDebugLogger{},
 		QOSPrefetch:     10,
 		QOSGlobal:       false,
@@ -64,6 +65,7 @@ func getDefaultBindingOptions() BindingOptions {
 type ConsumerOptions struct {
 	RabbitConsumerOptions RabbitConsumerOptions
 	QueueOptions          QueueOptions
+	CloseGracefully       bool
 	ExchangeOptions       []ExchangeOptions
 	Concurrency           int
 	Logger                logger.Logger
@@ -309,6 +311,12 @@ func WithConsumerOptionsQOSPrefetch(prefetchCount int) func(*ConsumerOptions) {
 // consumers on all channels on the same connection
 func WithConsumerOptionsQOSGlobal(options *ConsumerOptions) {
 	options.QOSGlobal = true
+}
+
+// WithConsumerOptionsForceShutdown tells the consumer to not wait for
+// the handlers to complete in consumer.Close
+func WithConsumerOptionsForceShutdown(options *ConsumerOptions) {
+	options.CloseGracefully = false
 }
 
 // WithConsumerOptionsQueueQuorum sets the queue a quorum type, which means

--- a/consumer_options.go
+++ b/consumer_options.go
@@ -314,7 +314,7 @@ func WithConsumerOptionsQOSGlobal(options *ConsumerOptions) {
 }
 
 // WithConsumerOptionsForceShutdown tells the consumer to not wait for
-// the handlers to complete in consumer.Close
+// the handler to complete in consumer.Close
 func WithConsumerOptionsForceShutdown(options *ConsumerOptions) {
 	options.CloseGracefully = false
 }


### PR DESCRIPTION
https://github.com/wagslane/go-rabbitmq/pull/150

Wait for consumer handler to finish before closing the channel and free up resources

Options:
- use WithConsumerOptionsForceShutdown option to disable this beheviour
- use consumer.CloseWithContext to cancel handler completion
