### PR TITLE
fix: initialise handlerMu in consumer (#169)

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -73,6 +73,7 @@ func NewConsumer(
 		reconnectErrCh:             reconnectErrCh,
 		closeConnectionToManagerCh: closeCh,
 		options:                    *options,
+		handlerMu:                  &sync.RWMutex{},
 		isClosedMu:                 &sync.RWMutex{},
 		isClosed:                   false,
 	}


### PR DESCRIPTION
See #169. The handlerMu isn't initialized, so this PR is intended as a breakfix to initialize it. I'm slightly concerned that this library doesn't have tests.