### PR TITLE
fix: goroutine leak in publisher on close

### DIFF
--- a/internal/connectionmanager/safe_wraps.go
+++ b/internal/connectionmanager/safe_wraps.go
@@ -8,10 +8,43 @@ import (
 func (connManager *ConnectionManager) NotifyBlockedSafe(
 	receiver chan amqp.Blocking,
 ) chan amqp.Blocking {
-	connManager.connectionMu.RLock()
-	defer connManager.connectionMu.RUnlock()
+	connManager.connectionMu.Lock()
+	defer connManager.connectionMu.Unlock()
 
-	return connManager.connection.NotifyBlocked(
-		receiver,
-	)
+	// add receiver to connection manager.
+	connManager.publisherNotifyBlockingReceiversMu.Lock()
+	connManager.publisherNotifyBlockingReceivers = append(connManager.publisherNotifyBlockingReceivers, receiver)
+	connManager.publisherNotifyBlockingReceiversMu.Unlock()
+
+	if !connManager.universalNotifyBlockingReceiverUsed {
+		connManager.connection.NotifyBlocked(
+			connManager.universalNotifyBlockingReceiver,
+		)
+		connManager.universalNotifyBlockingReceiverUsed = true
+	}
+
+	return receiver
+}
+
+// readUniversalBlockReceiver reads on universal blocking receiver and broadcasts event to all blocking receivers of
+// connection manager.
+func (connManager *ConnectionManager) readUniversalBlockReceiver() {
+	for b := range connManager.universalNotifyBlockingReceiver {
+		connManager.publisherNotifyBlockingReceiversMu.RLock()
+		for _, br := range connManager.publisherNotifyBlockingReceivers {
+			br <- b
+		}
+		connManager.publisherNotifyBlockingReceiversMu.RUnlock()
+	}
+}
+
+func (connManager *ConnectionManager) RemovePublisherBlockingReceiver(receiver chan amqp.Blocking) {
+	connManager.publisherNotifyBlockingReceiversMu.Lock()
+	for i, br := range connManager.publisherNotifyBlockingReceivers {
+		if br == receiver {
+			connManager.publisherNotifyBlockingReceivers = append(connManager.publisherNotifyBlockingReceivers[:i], connManager.publisherNotifyBlockingReceivers[i+1:]...)
+		}
+	}
+	connManager.publisherNotifyBlockingReceiversMu.Unlock()
+	close(receiver)
 }

--- a/publish.go
+++ b/publish.go
@@ -58,6 +58,8 @@ type Publisher struct {
 	notifyPublishHandler func(p Confirmation)
 
 	options PublisherOptions
+
+	blockings chan amqp.Blocking
 }
 
 type PublisherConfirmation []*amqp.DeferredConfirmation
@@ -286,6 +288,7 @@ func (publisher *Publisher) Close() {
 		publisher.options.Logger.Warnf("error while closing the channel: %v", err)
 	}
 	publisher.options.Logger.Infof("closing publisher...")
+	publisher.connManager.RemovePublisherBlockingReceiver(publisher.blockings)
 	go func() {
 		publisher.closeConnectionToManagerCh <- struct{}{}
 	}()

--- a/publish_flow_block.go
+++ b/publish_flow_block.go
@@ -26,6 +26,7 @@ func (publisher *Publisher) startNotifyFlowHandler() {
 func (publisher *Publisher) startNotifyBlockedHandler() {
 	blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking))
 	publisher.disablePublishDueToBlockedMu.Lock()
+	publisher.blockings = blockings
 	publisher.disablePublishDueToBlocked = false
 	publisher.disablePublishDueToBlockedMu.Unlock()
 


### PR DESCRIPTION
Hello,

Closing publisher did not close all associated goroutines. The routine listening for block events of connection only got terminated on closing the connection.
The wrapping connection manager holds all blocking channels and only passes down an universal blocking channel now. If a signal reaches this channel it is broadcasted to all blocking channels. This allows telling the connection manager to remove and close the channel if publisher is closed which will terminate the ` startNotifyBlockedHandler` method

Closes #149

So i moved to blocked handling of channels into the connection manager but i'm unsure if it is ok to use a second read write mutex for the blockings channel array. 