### PR TITLE
options: merge queue and exchange args instead of replacing

### DIFF
--- a/consumer_options.go
+++ b/consumer_options.go
@@ -144,10 +144,21 @@ func WithConsumerOptionsQueueNoDeclare(options *ConsumerOptions) {
 	options.QueueOptions.Declare = false
 }
 
-// WithConsumerOptionsQueueArgs adds optional args to the queue
+// WithConsumerOptionsQueueArgs adds optional args to the queue.
+//
+// If queue args were already set (for example by an earlier
+// WithConsumerOptionsQueueQuorum or WithConsumerOptionsQueueMessageExpiration)
+// the new args are merged onto the existing map rather than replacing
+// it. Earlier code replaced the whole map, so the order options were
+// passed in silently changed the resulting queue type. See #206.
 func WithConsumerOptionsQueueArgs(args Table) func(*ConsumerOptions) {
 	return func(options *ConsumerOptions) {
-		options.QueueOptions.Args = args
+		if options.QueueOptions.Args == nil {
+			options.QueueOptions.Args = Table{}
+		}
+		for k, v := range args {
+			options.QueueOptions.Args[k] = v
+		}
 	}
 }
 

--- a/consumer_options_test.go
+++ b/consumer_options_test.go
@@ -1,0 +1,45 @@
+package rabbitmq
+
+import "testing"
+
+// Regression for #206. WithConsumerOptionsQueueArgs used to overwrite
+// the entire args map, so any args set by an earlier option (e.g.
+// WithConsumerOptionsQueueQuorum or WithConsumerOptionsQueueMessageExpiration)
+// silently disappeared depending on option order.
+func TestWithConsumerOptionsQueueArgs_MergesWithExisting(t *testing.T) {
+	opts := &ConsumerOptions{}
+
+	WithConsumerOptionsQueueQuorum(opts)
+	if got := opts.QueueOptions.Args["x-queue-type"]; got != "quorum" {
+		t.Fatalf("quorum arg = %v, want %q", got, "quorum")
+	}
+
+	WithConsumerOptionsQueueArgs(Table{
+		"x-delivery-limit": -1,
+		"x-message-ttl":    6000,
+	})(opts)
+
+	if got := opts.QueueOptions.Args["x-queue-type"]; got != "quorum" {
+		t.Errorf("x-queue-type dropped after merge: got %v", got)
+	}
+	if got := opts.QueueOptions.Args["x-delivery-limit"]; got != -1 {
+		t.Errorf("x-delivery-limit = %v, want %v", got, -1)
+	}
+	if got := opts.QueueOptions.Args["x-message-ttl"]; got != 6000 {
+		t.Errorf("x-message-ttl = %v, want %v", got, 6000)
+	}
+}
+
+func TestWithPublisherOptionsExchangeArgs_MergesWithExisting(t *testing.T) {
+	opts := &PublisherOptions{}
+	opts.ExchangeOptions.Args = Table{"x-existing": "keep"}
+
+	WithPublisherOptionsExchangeArgs(Table{"x-new": "added"})(opts)
+
+	if got := opts.ExchangeOptions.Args["x-existing"]; got != "keep" {
+		t.Errorf("x-existing dropped: got %v", got)
+	}
+	if got := opts.ExchangeOptions.Args["x-new"]; got != "added" {
+		t.Errorf("x-new = %v, want %v", got, "added")
+	}
+}

--- a/publisher_options.go
+++ b/publisher_options.go
@@ -87,10 +87,19 @@ func WithPublisherOptionsExchangePassive(options *PublisherOptions) {
 	options.ExchangeOptions.Passive = true
 }
 
-// WithPublisherOptionsExchangeArgs adds optional args to the exchange
+// WithPublisherOptionsExchangeArgs adds optional args to the exchange.
+//
+// Merges onto any args already set on the exchange so callers can
+// stack options without the order silently overwriting earlier
+// settings. See #206 for the consumer-side analogue.
 func WithPublisherOptionsExchangeArgs(args Table) func(*PublisherOptions) {
 	return func(options *PublisherOptions) {
-		options.ExchangeOptions.Args = args
+		if options.ExchangeOptions.Args == nil {
+			options.ExchangeOptions.Args = Table{}
+		}
+		for k, v := range args {
+			options.ExchangeOptions.Args[k] = v
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #206.

\`WithConsumerOptionsQueueArgs\` and \`WithPublisherOptionsExchangeArgs\` assigned the passed \`Table\` straight onto \`options.QueueOptions.Args\` / \`ExchangeOptions.Args\`. Any args set by an earlier option in the same chain (the canonical case: \`WithConsumerOptionsQueueQuorum\`, which plants \`x-queue-type=quorum\`) was silently dropped depending on which order the user wrote the options in. The reporter's queue ended up declared as a classic queue instead of a quorum one with no warning.

Initialise the args map if nil and copy in the new entries so all options that fold into the same map stack instead of clobbering.

Added \`TestWithConsumerOptionsQueueArgs_MergesWithExisting\` and the publisher equivalent.