### PR TITLE
Test option argument order and precedence

### DIFF
--- a/consumer_options_test.go
+++ b/consumer_options_test.go
@@ -30,6 +30,31 @@ func TestWithConsumerOptionsQueueArgs_MergesWithExisting(t *testing.T) {
 	}
 }
 
+func TestWithConsumerOptionsQueueArgs_MergesBeforeQuorum(t *testing.T) {
+	opts := &ConsumerOptions{}
+
+	WithConsumerOptionsQueueArgs(Table{"x-delivery-limit": -1})(opts)
+	WithConsumerOptionsQueueQuorum(opts)
+
+	if got := opts.QueueOptions.Args["x-delivery-limit"]; got != -1 {
+		t.Errorf("x-delivery-limit = %v, want %v", got, -1)
+	}
+	if got := opts.QueueOptions.Args["x-queue-type"]; got != "quorum" {
+		t.Errorf("x-queue-type = %v, want %q", got, "quorum")
+	}
+}
+
+func TestWithConsumerOptionsQueueArgs_LaterValueWins(t *testing.T) {
+	opts := &ConsumerOptions{}
+
+	WithConsumerOptionsQueueArgs(Table{"x-message-ttl": 6000})(opts)
+	WithConsumerOptionsQueueArgs(Table{"x-message-ttl": 7000})(opts)
+
+	if got := opts.QueueOptions.Args["x-message-ttl"]; got != 7000 {
+		t.Errorf("x-message-ttl = %v, want %v", got, 7000)
+	}
+}
+
 func TestWithPublisherOptionsExchangeArgs_MergesWithExisting(t *testing.T) {
 	opts := &PublisherOptions{}
 	opts.ExchangeOptions.Args = Table{"x-existing": "keep"}
@@ -41,5 +66,16 @@ func TestWithPublisherOptionsExchangeArgs_MergesWithExisting(t *testing.T) {
 	}
 	if got := opts.ExchangeOptions.Args["x-new"]; got != "added" {
 		t.Errorf("x-new = %v, want %v", got, "added")
+	}
+}
+
+func TestWithPublisherOptionsExchangeArgs_LaterValueWins(t *testing.T) {
+	opts := &PublisherOptions{}
+
+	WithPublisherOptionsExchangeArgs(Table{"alternate-exchange": "first"})(opts)
+	WithPublisherOptionsExchangeArgs(Table{"alternate-exchange": "second"})(opts)
+
+	if got := opts.ExchangeOptions.Args["alternate-exchange"]; got != "second" {
+		t.Errorf("alternate-exchange = %v, want %q", got, "second")
 	}
 }


### PR DESCRIPTION
- Cover queue argument composition in both option orders
- Document that later queue argument values win on duplicate keys
- Apply the same precedence assertion to publisher exchange arguments