### PR TITLE
Restore confirm mode before channel reconnect

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -35,7 +36,7 @@ func prepareDockerTest(t *testing.T) (connStr string) {
 	return "amqp://guest:guest@localhost:5672/"
 }
 
-func waitForHealthyAmqp(t *testing.T, connStr string) *Conn {
+func waitForHealthyAmqp(t *testing.T, connStr string, optionFuncs ...func(*ConnectionOptions)) *Conn {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	tkr := time.NewTicker(time.Second)
@@ -56,7 +57,8 @@ func waitForHealthyAmqp(t *testing.T, connStr string) *Conn {
 			return nil
 		case <-tkr.C:
 			t.Log("attempting connection")
-			conn, err := NewConn(connStr, WithConnectionOptionsLogger(connLogger))
+			options := append(optionFuncs, WithConnectionOptionsLogger(connLogger))
+			conn, err := NewConn(connStr, options...)
 			if err != nil {
 				lastErr = err
 				t.Log("connection attempt failed - retrying")
@@ -67,6 +69,7 @@ func waitForHealthyAmqp(t *testing.T, connStr string) *Conn {
 						return fmt.Errorf("failed to setup publisher: %v", err)
 					}
 					t.Log("attempting publish")
+					defer pub.Close()
 					return pub.PublishWithContext(ctx, []byte{}, []string{"ping"}, WithPublishOptionsExchange(""))
 				}(); err != nil {
 					_ = conn.Close()
@@ -179,5 +182,62 @@ func TestPublisherCloseReleasesBlockedHandler(t *testing.T) {
 
 	if err := activePublisher.Publish([]byte("still connected"), []string{"unused"}); err != nil {
 		t.Fatalf("second publisher failed after first publisher closed: %v", err)
+	}
+}
+
+func TestPublisherRestoresConfirmModeBeforeReconnectCompletes(t *testing.T) {
+	connStr := prepareDockerTest(t)
+	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsReconnectInterval(10*time.Millisecond))
+	defer conn.Close()
+
+	tests := []struct {
+		name    string
+		options []func(*PublisherOptions)
+		dynamic bool
+	}{
+		{name: "configured", options: []func(*PublisherOptions){WithPublisherOptionsConfirm}},
+		{name: "dynamic", dynamic: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			publisher, err := NewPublisher(conn, test.options...)
+			if err != nil {
+				t.Fatal("error creating publisher", err)
+			}
+			defer publisher.Close()
+			if test.dynamic {
+				publisher.NotifyPublish(func(Confirmation) {})
+			}
+
+			for i := 0; i < 3; i++ {
+				reconnectionCount := publisher.chanManager.GetReconnectionCount()
+				_ = publisher.Publish(
+					[]byte("close channel"),
+					[]string{"unused"},
+					WithPublishOptionsExchange(fmt.Sprintf("missing-%d", i)),
+				)
+
+				deadline := time.Now().Add(2 * time.Second)
+				for publisher.chanManager.GetReconnectionCount() == reconnectionCount {
+					if time.Now().After(deadline) {
+						t.Fatal("timed out waiting for channel reconnect")
+					}
+					runtime.Gosched()
+				}
+
+				confirmations, err := publisher.PublishWithDeferredConfirmWithContext(
+					context.Background(),
+					[]byte("confirmed"),
+					[]string{"unused"},
+				)
+				if err != nil {
+					t.Fatal("publish after reconnect failed", err)
+				}
+				if len(confirmations) != 1 || confirmations[0] == nil {
+					t.Fatal("reconnected channel was published before confirm mode was restored")
+				}
+			}
+		})
 	}
 }

--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -21,6 +21,7 @@ type ChannelManager struct {
 	reconnectionCount   uint
 	reconnectionCountMu *sync.Mutex
 	dispatcher          *dispatcher.Dispatcher
+	confirmMode         bool
 }
 
 // NewChannelManager creates a new connection manager
@@ -119,7 +120,12 @@ func (chanManager *ChannelManager) reconnect() error {
 	if err != nil {
 		return err
 	}
-
+	if chanManager.confirmMode {
+		if err = newChannel.Confirm(false); err != nil {
+			_ = newChannel.Close()
+			return err
+		}
+	}
 	if err = chanManager.channel.Close(); err != nil {
 		chanManager.logger.Warnf("error closing channel while reconnecting: %v", err)
 	}

--- a/internal/channelmanager/safe_wraps.go
+++ b/internal/channelmanager/safe_wraps.go
@@ -206,9 +206,14 @@ func (chanManager *ChannelManager) ConfirmSafe(
 	chanManager.channelMu.Lock()
 	defer chanManager.channelMu.Unlock()
 
-	return chanManager.channel.Confirm(
-		noWait,
-	)
+	if chanManager.confirmMode {
+		return nil
+	}
+	if err := chanManager.channel.Confirm(noWait); err != nil {
+		return err
+	}
+	chanManager.confirmMode = true
+	return nil
 }
 
 // NotifyPublishSafe safely wraps the (*amqp.Channel).NotifyPublish method


### PR DESCRIPTION
Closes #186.

- Record successful confirm-mode activation in the channel manager
- Put replacement channels into confirm mode before exposing them to publishers
- Cover both publisher configuration and confirms enabled later through `NotifyPublish`
- Reproduce the original nil deferred-confirmation window across repeated Docker-backed reconnects

This supersedes #188, which only carries constructor-time confirm state and misses dynamically enabled confirms.