### PR TITLE
Keep consumers running through repeated recovery failures

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -102,12 +102,18 @@ func (consumer *Consumer) Run(handler Handler) error {
 
 	for err := range consumer.reconnectErrCh {
 		consumer.options.Logger.Infof("successful consumer recovery from: %v", err)
-		err = consumer.startGoroutines(
+		// If the broker crashes again between reconnect and the
+		// queue/exchange/binding declaration, startGoroutines returns
+		// an error. Don't bail out of the loop - the underlying channel
+		// manager will keep reconnecting and signal us again. Returning
+		// here used to permanently stop the consumer.
+		if err := consumer.startGoroutines(
 			handlerWrapper,
 			consumer.options,
-		)
-		if err != nil {
-			return fmt.Errorf("error restarting consumer goroutines after cancel or close: %w", err)
+		); err != nil {
+			consumer.options.Logger.Warnf(
+				"error restarting consumer goroutines after reconnect, waiting for next reconnect: %v", err,
+			)
 		}
 	}
 

--- a/consume.go
+++ b/consume.go
@@ -100,24 +100,30 @@ func (consumer *Consumer) Run(handler Handler) error {
 		return err
 	}
 
-	for err := range consumer.reconnectErrCh {
-		consumer.options.Logger.Infof("successful consumer recovery from: %v", err)
+	consumer.restartOnReconnect(func() error {
 		// If the broker crashes again between reconnect and the
 		// queue/exchange/binding declaration, startGoroutines returns
 		// an error. Don't bail out of the loop - the underlying channel
 		// manager will keep reconnecting and signal us again. Returning
 		// here used to permanently stop the consumer.
-		if err := consumer.startGoroutines(
+		return consumer.startGoroutines(
 			handlerWrapper,
 			consumer.options,
-		); err != nil {
+		)
+	})
+
+	return nil
+}
+
+func (consumer *Consumer) restartOnReconnect(restart func() error) {
+	for reconnectErr := range consumer.reconnectErrCh {
+		consumer.options.Logger.Infof("successful consumer recovery from: %v", reconnectErr)
+		if err := restart(); err != nil {
 			consumer.options.Logger.Warnf(
 				"error restarting consumer goroutines after reconnect, waiting for next reconnect: %v", err,
 			)
 		}
 	}
-
-	return nil
 }
 
 // Close cleans up resources and closes the consumer.

--- a/consume_test.go
+++ b/consume_test.go
@@ -1,0 +1,32 @@
+package rabbitmq
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestConsumerRestartContinuesAfterError(t *testing.T) {
+	reconnectErrCh := make(chan error, 2)
+	reconnectErrCh <- errors.New("first reconnect")
+	reconnectErrCh <- errors.New("second reconnect")
+	close(reconnectErrCh)
+
+	consumer := &Consumer{
+		reconnectErrCh: reconnectErrCh,
+		options: ConsumerOptions{
+			Logger: simpleLogF(t.Logf),
+		},
+	}
+	restarts := 0
+	consumer.restartOnReconnect(func() error {
+		restarts++
+		if restarts == 1 {
+			return errors.New("broker failed during declarations")
+		}
+		return nil
+	})
+
+	if restarts != 2 {
+		t.Fatalf("restart attempts = %d, want 2", restarts)
+	}
+}


### PR DESCRIPTION
Closes #211.

- Preserve the original #214 fix and contributor authorship
- Log a failed post-reconnect declaration restart instead of returning from `Consumer.Run`
- Continue processing later channel recovery notifications
- Add a deterministic regression test covering a failed restart followed by a successful one

This supersedes #214 by adding the missing regression coverage.