### PR TITLE
Honor publish contexts while channels reconnect

### DIFF
--- a/internal/channelmanager/safe_wraps.go
+++ b/internal/channelmanager/safe_wraps.go
@@ -2,9 +2,35 @@ package channelmanager
 
 import (
 	"context"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
+
+func (chanManager *ChannelManager) lockChannelRead(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if chanManager.channelMu.TryRLock() {
+		return nil
+	}
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if chanManager.channelMu.TryRLock() {
+				return nil
+			}
+		}
+	}
+}
 
 // ConsumeSafe safely wraps the (*amqp.Channel).Consume method
 func (chanManager *ChannelManager) ConsumeSafe(
@@ -158,7 +184,9 @@ func (chanManager *ChannelManager) PublishSafe(
 func (chanManager *ChannelManager) PublishWithContextSafe(
 	ctx context.Context, exchange string, key string, mandatory bool, immediate bool, msg amqp.Publishing,
 ) error {
-	chanManager.channelMu.RLock()
+	if err := chanManager.lockChannelRead(ctx); err != nil {
+		return err
+	}
 	defer chanManager.channelMu.RUnlock()
 
 	return chanManager.channel.PublishWithContext(
@@ -174,7 +202,9 @@ func (chanManager *ChannelManager) PublishWithContextSafe(
 func (chanManager *ChannelManager) PublishWithDeferredConfirmWithContextSafe(
 	ctx context.Context, exchange string, key string, mandatory bool, immediate bool, msg amqp.Publishing,
 ) (*amqp.DeferredConfirmation, error) {
-	chanManager.channelMu.RLock()
+	if err := chanManager.lockChannelRead(ctx); err != nil {
+		return nil, err
+	}
 	defer chanManager.channelMu.RUnlock()
 
 	return chanManager.channel.PublishWithDeferredConfirmWithContext(

--- a/internal/channelmanager/safe_wraps_test.go
+++ b/internal/channelmanager/safe_wraps_test.go
@@ -1,0 +1,73 @@
+package channelmanager
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func TestLockChannelReadHonorsContext(t *testing.T) {
+	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	manager.channelMu.Lock()
+	defer manager.channelMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	err := manager.lockChannelRead(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("lock error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("context cancellation took %s", elapsed)
+	}
+}
+
+func TestPublishWithContextSafeHonorsContextWhileChannelLocked(t *testing.T) {
+	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	manager.channelMu.Lock()
+	defer manager.channelMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := manager.PublishWithContextSafe(ctx, "", "key", false, false, amqp.Publishing{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("publish error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestPublishWithDeferredConfirmContextSafeHonorsContextWhileChannelLocked(t *testing.T) {
+	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	manager.channelMu.Lock()
+	defer manager.channelMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	confirmation, err := manager.PublishWithDeferredConfirmWithContextSafe(
+		ctx, "", "key", false, false, amqp.Publishing{},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("publish error = %v, want context deadline exceeded", err)
+	}
+	if confirmation != nil {
+		t.Fatal("confirmation should be nil after context cancellation")
+	}
+}
+
+func TestLockChannelReadRejectsCanceledContext(t *testing.T) {
+	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := manager.lockChannelRead(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("lock error = %v, want context canceled", err)
+	}
+}

--- a/publish.go
+++ b/publish.go
@@ -158,6 +158,8 @@ func (publisher *Publisher) Publish(
 }
 
 // PublishWithContext publishes the provided data to the given routing keys over the connection.
+// Context cancellation interrupts waiting for a channel that is reconnecting. Once an AMQP write
+// begins, the underlying amqp091-go client cannot interrupt it through context cancellation.
 func (publisher *Publisher) PublishWithContext(
 	ctx context.Context,
 	data []byte,
@@ -217,11 +219,13 @@ func (publisher *Publisher) PublishWithContext(
 	return nil
 }
 
-// PublishWithContext publishes the provided data to the given routing keys over the connection.
-// if the publisher is in confirm mode (which can be either done by calling `NotifyPublish` with a custom handler
+// PublishWithDeferredConfirmWithContext publishes the provided data to the given routing keys over the connection.
+// If the publisher is in confirm mode (which can be either done by calling `NotifyPublish` with a custom handler
 // or by using `WithPublisherOptionsConfirm`) a publisher confirmation is returned.
 // This confirmation can be used to check if the message was actually published or wait for this to happen.
 // If the publisher is not in confirm mode, the returned confirmation will always be nil.
+// Context cancellation interrupts waiting for a channel that is reconnecting, but cannot interrupt
+// an AMQP write after it begins.
 func (publisher *Publisher) PublishWithDeferredConfirmWithContext(
 	ctx context.Context,
 	data []byte,


### PR DESCRIPTION
Closes #189.

- Make normal and deferred-confirm publishes honor context cancellation while waiting for the channel recovery lock
- Return canceled contexts immediately, including when no recovery is active
- Add deterministic regression coverage for both publish paths under reconnect-style lock contention
- Document the upstream limitation that cancellation cannot interrupt AMQP I/O after a write begins