### PR TITLE
Update to Go 1.26 and amqp091-go v1.12.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,14 +13,14 @@ jobs:
       ENABLE_DOCKER_INTEGRATION_TESTS: TRUE
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.22"
-        id: go
-
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+        id: go
 
       - name: install staticcheck
         run: |

--- a/connection.go
+++ b/connection.go
@@ -1,7 +1,8 @@
 package rabbitmq
 
 import (
-	"math/rand"
+	"math/rand/v2"
+	"slices"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 
@@ -32,9 +33,7 @@ type StaticResolver struct {
 }
 
 func (r *StaticResolver) Resolve() ([]string, error) {
-	// TODO: move to slices.Clone when supported Go versions > 1.21
-	var urls []string
-	urls = append(urls, r.urls...)
+	urls := slices.Clone(r.urls)
 
 	if r.shuffle {
 		rand.Shuffle(len(urls), func(i, j int) {

--- a/consume.go
+++ b/consume.go
@@ -226,7 +226,7 @@ func (consumer *Consumer) startGoroutines(
 		return err
 	}
 
-	for i := 0; i < options.Concurrency; i++ {
+	for range options.Concurrency {
 		go handlerGoroutine(consumer, msgs, options, handler)
 	}
 	consumer.options.Logger.Infof("Processing messages on %v goroutines", options.Concurrency)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/wagslane/go-rabbitmq
 
-go 1.22.6
+go 1.26.0
 
-require github.com/rabbitmq/amqp091-go v1.10.0
+require github.com/rabbitmq/amqp091-go v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
-github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/rabbitmq/amqp091-go v1.12.0 h1:V0v14Iqfs+MwHWihJt/nGS5Ulu0vw572b2Co3mwunkI=
+github.com/rabbitmq/amqp091-go v1.12.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -3,7 +3,7 @@ package dispatcher
 import (
 	"log"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 )
@@ -43,9 +43,7 @@ func (d *Dispatcher) Dispatch(err error) error {
 
 // AddSubscriber -
 func (d *Dispatcher) AddSubscriber() (<-chan error, chan<- struct{}) {
-	const maxRand = math.MaxInt
-	const minRand = 0
-	id := rand.Intn(maxRand-minRand) + minRand
+	id := rand.IntN(math.MaxInt)
 
 	closeCh := make(chan struct{})
 	notifyCancelOrCloseChan := make(chan error)

--- a/table.go
+++ b/table.go
@@ -1,6 +1,10 @@
 package rabbitmq
 
-import amqp "github.com/rabbitmq/amqp091-go"
+import (
+	"maps"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
 
 // Table stores user supplied fields of the following types:
 //
@@ -33,9 +37,7 @@ import amqp "github.com/rabbitmq/amqp091-go"
 type Table map[string]interface{}
 
 func tableToAMQPTable(table Table) amqp.Table {
-	new := amqp.Table{}
-	for k, v := range table {
-		new[k] = v
-	}
-	return new
+	amqpTable := make(amqp.Table, len(table))
+	maps.Copy(amqpTable, table)
+	return amqpTable
 }

--- a/vendor/github.com/rabbitmq/amqp091-go/.gitignore
+++ b/vendor/github.com/rabbitmq/amqp091-go/.gitignore
@@ -1,6 +1,14 @@
+# Certificates
 certs/*
-spec/spec
-examples/simple-consumer/simple-consumer
-examples/simple-producer/simple-producer
 
+# Specs
+spec/spec
+
+# Example binaries
+_examples/consumer/consumer
+_examples/producer/producer
+_examples/client/client
+_examples/pubsub/pubsub
+
+# IDEs and Editors
 .idea/

--- a/vendor/github.com/rabbitmq/amqp091-go/.golangci.yml
+++ b/vendor/github.com/rabbitmq/amqp091-go/.golangci.yml
@@ -1,3 +1,42 @@
+version: "2"
 run:
   build-tags:
     - integration
+linters:
+  default: standard
+  enable:
+    - modernize
+  disable:
+    - testpackage
+    - testableexamples
+    - godox
+    - gochecknoinits
+  settings:
+    modernize:
+      disable:
+        # enable when
+        - minmax
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+    rules:
+      - linters:
+          - funlen
+          - gocognit
+          - cyclop
+        source: "integration_test.go"
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/vendor/github.com/rabbitmq/amqp091-go/CHANGELOG.md
+++ b/vendor/github.com/rabbitmq/amqp091-go/CHANGELOG.md
@@ -1,5 +1,86 @@
 # Changelog
 
+## [v1.12.0](https://github.com/rabbitmq/amqp091-go/tree/v1.12.0) (2026-06-16)
+
+[Full Changelog](https://github.com/rabbitmq/amqp091-go/compare/v1.11.0...v1.12.0)
+
+**Implemented enhancements:**
+
+- Feature: implement automatic connection and channel recovery with state change notifications [\#339](https://github.com/rabbitmq/amqp091-go/pull/339) ([suchitd](https://github.com/suchitd))
+- Add integration test for publish with immediate flag [\#338](https://github.com/rabbitmq/amqp091-go/pull/338) ([suchitd](https://github.com/suchitd))
+- Add integration tests for QueueUnbind and QueuePurge [\#337](https://github.com/rabbitmq/amqp091-go/pull/337) ([suchitd](https://github.com/suchitd))
+- Add integration test for exchange-to-exchange binding and unbinding [\#336](https://github.com/rabbitmq/amqp091-go/pull/336) ([suchitd](https://github.com/suchitd))
+
+**Fixed bugs:**
+
+- Fix Client example to work with RabbitMQ 4.3 [\#341](https://github.com/rabbitmq/amqp091-go/pull/341) ([suchitd](https://github.com/suchitd))
+- Update CONTRIBUTING.md and .gitignore files [\#335](https://github.com/rabbitmq/amqp091-go/pull/335) ([suchitd](https://github.com/suchitd))
+- Fix inconsistencies in the Makefile [\#334](https://github.com/rabbitmq/amqp091-go/pull/334) ([suchitd](https://github.com/suchitd))
+- Fix integration tests for RabbitMQ 4.3 [\#331](https://github.com/rabbitmq/amqp091-go/pull/331) ([suchitd](https://github.com/suchitd))
+
+**Closed issues:**
+
+- PublishWithContext does not respect context cancellation [\#329](https://github.com/rabbitmq/amqp091-go/issues/329)
+
+**Merged pull requests:**
+
+- doc: remove auto-reconnect from non-goals in README [\#343](https://github.com/rabbitmq/amqp091-go/pull/343) ([suchitd](https://github.com/suchitd))
+- Add CLAUDE.md to repo [\#342](https://github.com/rabbitmq/amqp091-go/pull/342) ([Zerpet](https://github.com/Zerpet))
+- Bump CI windows workflow RabbitMQ and Erlang versions [\#333](https://github.com/rabbitmq/amqp091-go/pull/333) ([suchitd](https://github.com/suchitd))
+- Add pull request template [\#332](https://github.com/rabbitmq/amqp091-go/pull/332) ([suchitd](https://github.com/suchitd))
+
+## [v1.11.0](https://github.com/rabbitmq/amqp091-go/tree/v1.11.0) (2026-04-21)
+
+[Full Changelog](https://github.com/rabbitmq/amqp091-go/compare/v1.10.0...v1.11.0)
+
+**Implemented enhancements:**
+
+- add better debug information on DialConfig [\#245](https://github.com/rabbitmq/amqp091-go/issues/245)
+
+**Fixed bugs:**
+
+- Channel error when acking via go-routines [\#296](https://github.com/rabbitmq/amqp091-go/issues/296)
+
+**Closed issues:**
+
+- PR \#318 exposes a pre-existing race in `Connection.Close()`. [\#327](https://github.com/rabbitmq/amqp091-go/issues/327)
+- Entire header frame isn't always read [\#309](https://github.com/rabbitmq/amqp091-go/issues/309)
+- Incomplete support of 0-9-1 field type values [\#302](https://github.com/rabbitmq/amqp091-go/issues/302)
+- Redelivered Flag Not Exposed [\#301](https://github.com/rabbitmq/amqp091-go/issues/301)
+- consume input basicConsumeOk but response queueBindOk [\#291](https://github.com/rabbitmq/amqp091-go/issues/291)
+- Channel is closed after Channel.ExchangeDeclarePassive fails [\#290](https://github.com/rabbitmq/amqp091-go/issues/290)
+- Incomplete example in \(\*Channel\).QueueBind documentation [\#279](https://github.com/rabbitmq/amqp091-go/issues/279)
+- QueueDeclarePassive does not report queue type mismatch [\#273](https://github.com/rabbitmq/amqp091-go/issues/273)
+- Release 1.10.0 [\#261](https://github.com/rabbitmq/amqp091-go/issues/261)
+- Update minimum Go version to 1.18 [\#146](https://github.com/rabbitmq/amqp091-go/issues/146)
+
+**Merged pull requests:**
+
+-  fix: respect context cancellation on publishing with context operations [\#330](https://github.com/rabbitmq/amqp091-go/pull/330) ([NawafSwe](https://github.com/NawafSwe))
+- Eliminate race condition in Connection.Close\(\) and related methods [\#328](https://github.com/rabbitmq/amqp091-go/pull/328) ([Zerpet](https://github.com/Zerpet))
+- Bump the github-actions group with 4 updates [\#326](https://github.com/rabbitmq/amqp091-go/pull/326) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump github/codeql-action from 3 to 4 [\#321](https://github.com/rabbitmq/amqp091-go/pull/321) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Fix incomplete routing diagram in QueueBind doc comment [\#320](https://github.com/rabbitmq/amqp091-go/pull/320) ([Copilot](https://github.com/apps/copilot-swe-agent))
+- Use RabbitMQ 4 in Makefile [\#319](https://github.com/rabbitmq/amqp091-go/pull/319) ([Zerpet](https://github.com/Zerpet))
+- refactor: simplify with atomic types [\#318](https://github.com/rabbitmq/amqp091-go/pull/318) ([alexandear](https://github.com/alexandear))
+- Add support for unsigned type values [\#317](https://github.com/rabbitmq/amqp091-go/pull/317) ([Zerpet](https://github.com/Zerpet))
+- fix: modernize lint issues [\#315](https://github.com/rabbitmq/amqp091-go/pull/315) ([alexandear](https://github.com/alexandear))
+- Fix `parseHeaderFrame` to consume entire frame payload [\#314](https://github.com/rabbitmq/amqp091-go/pull/314) ([lukebakken](https://github.com/lukebakken))
+- docs: update link to RabbitMQ tutorials [\#313](https://github.com/rabbitmq/amqp091-go/pull/313) ([alexandear](https://github.com/alexandear))
+- fix: typos in comments and tests [\#312](https://github.com/rabbitmq/amqp091-go/pull/312) ([alexandear](https://github.com/alexandear))
+- feat: add MIME types constants for  content types [\#308](https://github.com/rabbitmq/amqp091-go/pull/308) ([YlanzinhoY](https://github.com/YlanzinhoY))
+- Fix linter error after migrating config to v2 [\#306](https://github.com/rabbitmq/amqp091-go/pull/306) ([Zerpet](https://github.com/Zerpet))
+- Investigate GH-296 [\#297](https://github.com/rabbitmq/amqp091-go/pull/297) ([lukebakken](https://github.com/lukebakken))
+- Return existing error instead of creating new for the same purpose [\#295](https://github.com/rabbitmq/amqp091-go/pull/295) ([pingvincible](https://github.com/pingvincible))
+- Add warning about concurrency with Channels [\#294](https://github.com/rabbitmq/amqp091-go/pull/294) ([Zerpet](https://github.com/Zerpet))
+- Expose delivery not initialised error [\#293](https://github.com/rabbitmq/amqp091-go/pull/293) ([Zerpet](https://github.com/Zerpet))
+- fix: unify receiver methods to avoid conflicts between value and pointer types [\#292](https://github.com/rabbitmq/amqp091-go/pull/292) ([Raisul191491](https://github.com/Raisul191491))
+- Fixing simple errors [\#280](https://github.com/rabbitmq/amqp091-go/pull/280) ([korolev-d-l](https://github.com/korolev-d-l))
+- Add test that demonstrates the issue [\#274](https://github.com/rabbitmq/amqp091-go/pull/274) ([lukebakken](https://github.com/lukebakken))
+- chore: doc typo [\#269](https://github.com/rabbitmq/amqp091-go/pull/269) ([AndrewWinterman](https://github.com/AndrewWinterman))
+- Small fixes and refactors [\#266](https://github.com/rabbitmq/amqp091-go/pull/266) ([peczenyj](https://github.com/peczenyj))
+- add methods Temporary and Recoverable to amqp.Error [\#265](https://github.com/rabbitmq/amqp091-go/pull/265) ([peczenyj](https://github.com/peczenyj))
+
 ## [v1.10.0](https://github.com/rabbitmq/amqp091-go/tree/v1.10.0) (2024-05-08)
 
 [Full Changelog](https://github.com/rabbitmq/amqp091-go/compare/v1.9.0...v1.10.0)

--- a/vendor/github.com/rabbitmq/amqp091-go/CLAUDE.md
+++ b/vendor/github.com/rabbitmq/amqp091-go/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About
+
+`amqp091-go` is the official Go AMQP 0.9.1 client maintained by the RabbitMQ core team (`github.com/rabbitmq/amqp091-go`). It is a single root package with no external runtime dependencies (only `go.uber.org/goleak` for tests).
+
+## Commands
+
+```bash
+# Format
+make fmt
+make check-fmt       # check-only, no writes
+
+# Lint
+make checks          # golangci-lint (must be installed)
+
+# Integration tests — require a running RabbitMQ on localhost:5672
+make tests
+make tests-docker    # spins up RabbitMQ in Docker, runs, then tears down
+
+# Run a specific test
+go test -race -v -tags integration -run TestIntegrationOpenClose
+
+# Start / stop Dockerized RabbitMQ manually
+make rabbitmq-server
+make stop-rabbitmq-server
+```
+
+Integration tests use the `integration` build tag. Without it (or without a running broker), only unit tests run. The env var `RABBITMQ_RABBITMQCTL_PATH=DOCKER:<container>` (or path to a local `rabbitmqctl` executable) enables administrative/broker control tests.
+
+## Architecture
+
+All core code is in the root package (excluding examples under `_examples/` and generator files under `spec/`).
+
+### Layers
+
+```
+Caller
+  └─ Connection (connection.go)     TCP socket, AMQP handshake, heartbeat, frame mux
+       ├─ read.go / write.go        frame (de)serialization
+       └─ Channel (channel.go)      AMQP channel — all protocol methods
+            ├─ confirms.go          publisher confirm tracking
+            └─ consumers.go         consumer tag → delivery channel dispatch
+```
+
+`spec091.go` is auto-generated from the AMQP 0.9.1 spec XML. Do not hand-edit it.
+
+### Connection
+
+- `Dial` / `DialConfig` / `DialTLS` are the entry points; `DialConfig` is the most general.
+- One **reader goroutine** (`connection.reader`) reads frames from the socket and calls `demux` to route them to channels.
+- One **heartbeater goroutine** (`connection.heartbeater`) monitors activity and sends keep-alive frames.
+- Channels are tracked in `Connection.channels map[uint16]*Channel`. Channel 0 is reserved for connection-level control frames.
+
+### Channel
+
+- Obtained via `conn.Channel()`.
+- All AMQP operations (declare, bind, publish, consume, ack, transactions) are methods on `Channel`.
+- RPC-style operations call `call()`, which sends a method frame and blocks on the reply. Non-RPC sends are fire-and-forget.
+- Concurrent publishes from multiple goroutines are safe; the write side is mutex-protected via `Connection.sendM`.
+
+### Frame assembly state machine
+
+`Channel.recv` is a function pointer that acts as a state machine:
+
+```
+recvMethod  →  (method with content)  →  recvHeader  →  recvContent  →  recvMethod
+           →  (method without content: dispatch immediately, stay in recvMethod)
+```
+
+Body can span multiple `frameBody` frames; `Channel` accumulates them before dispatch.
+
+### Publisher confirms (`confirms.go`)
+
+`Channel.Confirm(noWait)` enables confirm mode. Each subsequent publish is assigned a monotonically increasing delivery tag. The broker acknowledges with `basic.ack` / `basic.nack` frames, which may arrive out of order. `confirms.resequence()` buffers out-of-order acks and delivers them in order to all listeners. `DeferredConfirmation` provides a future-style API (`Wait`, `WaitContext`, `Acked`).
+
+### Consumer dispatch (`consumers.go`)
+
+`Channel.Consume` registers a consumer tag and launches a **buffer goroutine** per consumer that relays deliveries from an internal `chan *Delivery` to the application-facing `chan Delivery`. This decouples the reader goroutine from application consumption speed. Buffer goroutines nil out slice elements explicitly to aid GC under high load.
+
+### Notify channels
+
+All `Notify*` methods (`NotifyClose`, `NotifyBlocked`, `NotifyFlow`, `NotifyReturn`, `NotifyCancel`, `NotifyConfirm`, `NotifyPublish`) follow the same contract:
+
+- The caller provides a channel (buffered recommended).
+- The library writes to it and **closes it** when the entity shuts down.
+- Multiple registrations result in a broadcast — all listeners receive every event.
+- Reading from a closed listener channel signals shutdown.
+
+### No automatic reconnection
+
+By design, the library does **not** reconnect automatically. Applications detect closure via `NotifyClose` and re-establish connections and declare topology themselves. The `_examples/client/client.go` demonstrates a reconnecting wrapper pattern.
+
+## Key conventions
+
+- `*Error` (`types.go`) carries an AMQP reply code and whether the error is recoverable. Server-initiated closes arrive on `NotifyClose` channels as `*Error`.
+- `Table` is `map[string]interface{}` with a restricted set of allowed value types enumerated in `types.go`.
+- Mutexes follow a strict order: `Connection.m` → `Channel.m` (never the reverse) to avoid deadlock.
+- `atomic.Bool` flags (`Connection.closed`, `Channel.closed`) allow lock-free early-exit checks on the hot path.

--- a/vendor/github.com/rabbitmq/amqp091-go/CONTRIBUTING.md
+++ b/vendor/github.com/rabbitmq/amqp091-go/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Here is the recommended workflow:
 ## Running Static Checks
 
 golangci-lint must be installed to run the static checks. See [installation
-docs](https://golangci-lint.run/usage/install/) for more information.
+docs](https://golangci-lint.run/docs/welcome/install/local/) for more information.
 
 The static checks can be run via:
 
@@ -31,13 +31,12 @@ make checks
 
 ### Integration Tests
 
-Running the Integration tests require:
+Running the Integration tests requires:
 
-* A running RabbitMQ node with all defaults:
-  [https://www.rabbitmq.com/download.html](https://www.rabbitmq.com/download.html)
-* That the server is either reachable via `amqp://guest:guest@127.0.0.1:5672/`
-  or the environment variable `AMQP_URL` set to it's URL
-  (e.g.: `export AMQP_URL="amqp://guest:verysecretpasswd@rabbitmq-host:5772/`)
+* A running [RabbitMQ](https://www.rabbitmq.com/download.html) node with all defaults
+* The server is either reachable via `amqp://guest:guest@127.0.0.1:5672/`
+  or the environment variable `AMQP_URL` is set to its URL
+  (e.g.: `export AMQP_URL="amqp://guest:verysecretpasswd@rabbitmq-host:5672/"`)
 
 The integration tests can be run via:
 
@@ -46,7 +45,7 @@ make tests
 ```
 
 Some tests require access to `rabbitmqctl` CLI. Use the environment variable
-`RABBITMQ_RABBITMQCTL_PATH=/some/path/to/rabbitmqctl` to run those tests. 
+`RABBITMQ_RABBITMQCTL_PATH=/some/path/to/rabbitmqctl` to run those tests.
 
 If you have Docker available in your machine, you can run:
 

--- a/vendor/github.com/rabbitmq/amqp091-go/Makefile
+++ b/vendor/github.com/rabbitmq/amqp091-go/Makefile
@@ -20,12 +20,12 @@ tests: ## Run all tests and requires a running rabbitmq-server. Use GO_TEST_FLAG
 	go test -race -v -tags integration $(GO_TEST_FLAGS)
 
 .PHONY: tests-docker
-tests-docker: rabbitmq-server
+tests-docker: rabbitmq-server ## Run integration tests against a Dockerized RabbitMQ
 	RABBITMQ_RABBITMQCTL_PATH="DOCKER:$(CONTAINER_NAME)" go test -race -v -tags integration $(GO_TEST_FLAGS)
 	$(MAKE) stop-rabbitmq-server
 
-.PHONY: check
-check:
+.PHONY: checks
+checks: ## Run static checks (golangci-lint)
 	golangci-lint run ./...
 
 CONTAINER_NAME ?= amqp091-go-rabbitmq
@@ -34,17 +34,17 @@ CONTAINER_NAME ?= amqp091-go-rabbitmq
 rabbitmq-server: ## Start a RabbitMQ server using Docker. Container name can be customised with CONTAINER_NAME=some-rabbit
 	docker run --detach --rm --name $(CONTAINER_NAME) \
 		--publish 5672:5672 --publish 15672:15672 \
-		--pull always rabbitmq:3-management
+		--pull always rabbitmq:4-management
 
 .PHONY: stop-rabbitmq-server
 stop-rabbitmq-server: ## Stop a RabbitMQ server using Docker. Container name can be customised with CONTAINER_NAME=some-rabbit
 	docker stop $(CONTAINER_NAME)
 
-certs:
+certs: ## Generate TLS certificates under ./certs/ via certs.sh
 	./certs.sh
 
 .PHONY: certs-rm
-certs-rm:
+certs-rm: ## Remove the generated ./certs/ directory
 	rm -r ./certs/
 
 .PHONY: rabbitmq-server-tls
@@ -54,4 +54,4 @@ rabbitmq-server-tls: | certs ## Start a RabbitMQ server using Docker. Container 
 		--mount type=bind,src=./certs/server,dst=/certs \
 		--mount type=bind,src=./certs/ca/cacert.pem,dst=/certs/cacert.pem,readonly \
 		--mount type=bind,src=./rabbitmq-confs/tls/90-tls.conf,dst=/etc/rabbitmq/conf.d/90-tls.conf \
-		--pull always rabbitmq:3-management
+		--pull always rabbitmq:4-management

--- a/vendor/github.com/rabbitmq/amqp091-go/README.md
+++ b/vendor/github.com/rabbitmq/amqp091-go/README.md
@@ -60,16 +60,6 @@ interact the semantics of the protocol.
 
 Things not intended to be supported.
 
-  * Auto reconnect and re-synchronization of client and server topologies.
-    * Reconnection would require understanding the error paths when the
-      topology cannot be declared on reconnect.  This would require a new set
-      of types and code paths that are best suited at the call-site of this
-      package.  AMQP has a dynamic topology that needs all peers to agree. If
-      this doesn't happen, the behavior is undefined.  Instead of producing a
-      possible interface with undefined behavior, this package is designed to
-      be simple for the caller to implement the necessary connection-time
-      topology declaration so that reconnection is trivial and encapsulated in
-      the caller's application code.
   * AMQP Protocol negotiation for forward or backward compatibility.
     * 0.9.1 is stable and widely deployed.  AMQP 1.0 is a divergent
       specification (a different protocol) and belongs to a different library.
@@ -90,7 +80,7 @@ please file an issue.
 ## Documentation
 
  * [Godoc API reference](http://godoc.org/github.com/rabbitmq/amqp091-go)
- * [RabbitMQ tutorials in Go](https://github.com/rabbitmq/rabbitmq-tutorials/tree/master/go)
+ * [RabbitMQ tutorials in Go](https://github.com/rabbitmq/rabbitmq-tutorials/tree/main/go)
 
 ## Contributing
 

--- a/vendor/github.com/rabbitmq/amqp091-go/allocator.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/allocator.go
@@ -6,9 +6,9 @@
 package amqp091
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
+	"strings"
 )
 
 const (
@@ -42,9 +42,9 @@ func newAllocator(low, high int) *allocator {
 // "allocator[low..high] reserved..until"
 //
 // O(N) where N is high-low
-func (a allocator) String() string {
-	b := &bytes.Buffer{}
-	fmt.Fprintf(b, "allocator[%d..%d]", a.low, a.high)
+func (a *allocator) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "allocator[%d..%d]", a.low, a.high)
 
 	for low := a.low; low <= a.high; low++ {
 		high := low
@@ -53,9 +53,9 @@ func (a allocator) String() string {
 		}
 
 		if high > low+1 {
-			fmt.Fprintf(b, " %d..%d", low, high-1)
+			fmt.Fprintf(&b, " %d..%d", low, high-1)
 		} else if high > low {
-			fmt.Fprintf(b, " %d", high-1)
+			fmt.Fprintf(&b, " %d", high-1)
 		}
 
 		low = high

--- a/vendor/github.com/rabbitmq/amqp091-go/auth.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/auth.go
@@ -55,8 +55,7 @@ func (auth *AMQPlainAuth) Response() string {
 }
 
 // ExternalAuth for RabbitMQ-auth-mechanism-ssl.
-type ExternalAuth struct {
-}
+type ExternalAuth struct{}
 
 // Mechanism returns "EXTERNAL"
 func (*ExternalAuth) Mechanism() string {
@@ -70,7 +69,6 @@ func (*ExternalAuth) Response() string {
 
 // Finds the first mechanism preferred by the client that the server supports.
 func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth Authentication, ok bool) {
-
 	for _, auth = range client {
 		for _, mech := range serverMechanisms {
 			if auth.Mechanism() == mech {

--- a/vendor/github.com/rabbitmq/amqp091-go/channel.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/channel.go
@@ -7,9 +7,12 @@ package amqp091
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"reflect"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // 0      1         3             7                  size+7 size+8
@@ -26,10 +29,11 @@ exchange.  Errors on methods with this Channel as a receiver means this channel
 should be discarded and a new channel established.
 */
 type Channel struct {
-	destructor sync.Once
-	m          sync.Mutex // struct field mutex
-	confirmM   sync.Mutex // publisher confirms state mutex
-	notifyM    sync.RWMutex
+	destructorM sync.Mutex   // Mutex for destroying the channel.
+	destructed  bool         // Will be true if the channel has been destroyed, false otherwise.
+	m           sync.Mutex   // Mutex for the channel.
+	confirmM    sync.Mutex   // Mutex for the publisher confirms state.
+	notifyM     sync.RWMutex // Mutex for the notify state.
 
 	connection *Connection
 
@@ -38,8 +42,8 @@ type Channel struct {
 
 	id uint16
 
-	// closed is set to 1 when the channel has been closed - see Channel.send()
-	closed int32
+	// closed is set to true when the channel has been closed - see Channel.send()
+	closed atomic.Bool
 	close  chan struct{}
 
 	// true when we will never notify again
@@ -74,6 +78,11 @@ type Channel struct {
 	message messageWithContent
 	header  *headerFrame
 	body    []byte
+
+	reconnecting sync.Mutex // Mutex for reconnecting channel.
+	lifeCycle    *lifeCycle // The current state of the channel.
+
+	recoveryCancels []chan struct{} // listeners for channel recovery cancellation
 }
 
 // Constructs a new channel with the given framing rules
@@ -87,12 +96,13 @@ func newChannel(c *Connection, id uint16) *Channel {
 		recv:       (*Channel).recvMethod,
 		errors:     make(chan *Error, 1),
 		close:      make(chan struct{}),
+		lifeCycle:  newLifeCycle(),
 	}
 }
 
 // Signal that from now on, Channel.send() should call Channel.sendClosed()
 func (ch *Channel) setClosed() {
-	atomic.StoreInt32(&ch.closed, 1)
+	ch.closed.Store(true)
 }
 
 // shutdown is called by Connection after the channel has been removed from the
@@ -100,23 +110,48 @@ func (ch *Channel) setClosed() {
 func (ch *Channel) shutdown(e *Error) {
 	ch.setClosed()
 
-	ch.destructor.Do(func() {
-		ch.m.Lock()
-		defer ch.m.Unlock()
+	ch.destructorM.Lock()
+	if ch.destructed {
+		ch.destructorM.Unlock()
+		return
+	}
+	ch.destructed = true
+	defer ch.destructorM.Unlock()
 
-		// Grab an exclusive lock for the notify channels
-		ch.notifyM.Lock()
-		defer ch.notifyM.Unlock()
+	ch.m.Lock()
+	defer ch.m.Unlock()
 
-		// Broadcast abnormal shutdown
-		if e != nil {
-			for _, c := range ch.closes {
-				c <- e
+	// Grab an exclusive lock for the notify channels
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
+
+	// Broadcast abnormal shutdown
+	if e != nil {
+		for _, c := range ch.closes {
+			select {
+			case c <- e:
+			default:
+				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
+				go func(c chan *Error, e *Error) {
+					defer func() {
+						_ = recover() // Gracefully ignore panics if the channel is closed concurrently
+					}()
+					select {
+					case c <- e:
+					case <-time.After(5 * time.Second):
+						// Give up to avoid leaking the goroutine permanently
+					}
+				}(c, e)
 			}
-			// Notify RPC if we're selecting
-			ch.errors <- e
 		}
+		// Notify RPC if we're selecting
+		select {
+		case ch.errors <- e:
+		default:
+		}
+	}
 
+	if e == nil || !ch.connection.IsRecoveryEnabled() || !ch.connection.isRecoverable(e) {
 		ch.consumers.close()
 
 		for _, c := range ch.closes {
@@ -149,7 +184,16 @@ func (ch *Channel) shutdown(e *Error) {
 		close(ch.errors)
 		close(ch.close)
 		ch.noNotify = true
-	})
+
+		var err error
+		if e != nil {
+			err = fmt.Errorf("%w", e) // preserve the original error type for assertions
+		}
+		ch.lifeCycle.SetState(StateClosed, err)
+	} else {
+		close(ch.errors)
+		close(ch.close)
+	}
 }
 
 // send calls Channel.sendOpen() during normal operation.
@@ -307,7 +351,7 @@ func (ch *Channel) sendOpen(msg message) (err error) {
 func (ch *Channel) dispatch(msg message) {
 	switch m := msg.(type) {
 	case *channelClose:
-		// Note: channel state is set to closed immedately after the message is
+		// Note: channel state is set to closed immediately after the message is
 		// decoded by the Connection
 
 		// lock before sending connection.close-ok
@@ -474,9 +518,13 @@ code set to '200'.
 It is safe to call this method multiple times.
 */
 func (ch *Channel) Close() error {
+	ch.closeRecovery() // Stop any active recovery process
+
 	if ch.IsClosed() {
 		return nil
 	}
+
+	ch.lifeCycle.SetState(StateClosing, nil)
 
 	defer ch.connection.closeChannel(ch, nil)
 	return ch.call(
@@ -488,7 +536,15 @@ func (ch *Channel) Close() error {
 // IsClosed returns true if the channel is marked as closed, otherwise false
 // is returned.
 func (ch *Channel) IsClosed() bool {
-	return atomic.LoadInt32(&ch.closed) == 1
+	return ch.closed.Load()
+}
+
+// NotifyStateChange registers a listener for state changes.
+//
+// It is necessary to continuously consume from the channel passed to NotifyStateChange
+// to avoid blocking internal state dispatch routines and leaking goroutines.
+func (ch *Channel) NotifyStateChange(c chan *StateChanged) {
+	ch.lifeCycle.notifyStateChange(c)
 }
 
 /*
@@ -515,6 +571,37 @@ func (ch *Channel) NotifyClose(c chan *Error) chan *Error {
 	}
 
 	return c
+}
+
+/*
+NotifyRecoveryCancel registers a listener that is notified (via a channel close)
+when channel recovery has been canceled or aborted (for example, when Close()
+is called during an active channel reconnect process).
+*/
+func (ch *Channel) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
+	state := ch.lifeCycle.State()
+	if state == StateClosing || state == StateClosed {
+		close(receiver)
+	} else {
+		ch.recoveryCancels = append(ch.recoveryCancels, receiver)
+	}
+
+	return receiver
+}
+
+// closeRecovery stops any active channel recovery process by notifying
+// and closing all recovery cancellation listeners.
+func (ch *Channel) closeRecovery() {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
+	for _, listener := range ch.recoveryCancels {
+		close(listener)
+	}
+	ch.recoveryCancels = nil
 }
 
 /*
@@ -926,8 +1013,7 @@ exchange and queue, the attempt to rebind will be ignored and the existing
 binding will be retained.
 
 In the case that multiple bindings may cause the message to be routed to the
-same queue, the server will only route the publishing once.  This is possible
-with topic exchanges.
+same queue, the server will route the publishing to all queues that match.
 
 	QueueBind("pagers", "alert", "amq.topic", false, nil)
 	QueueBind("emails", "info", "amq.topic", false, nil)
@@ -936,6 +1022,7 @@ with topic exchanges.
 	Delivery       Exchange        Key       Queue
 	-----------------------------------------------
 	key: alert --> amq.topic ----> alert --> pagers
+	                         \---> # ------> emails
 	key: info ---> amq.topic ----> # ------> emails
 	                         \---> info ---/
 	key: debug --> amq.topic ----> # ------> emails
@@ -1124,7 +1211,16 @@ func (ch *Channel) Consume(queue, consumer string, autoAck, exclusive, noLocal, 
 
 	deliveries := make(chan Delivery)
 
-	ch.consumers.add(consumer, deliveries)
+	config := consumerConfig{
+		Queue:     queue,
+		Consumer:  consumer,
+		AutoAck:   autoAck,
+		Exclusive: exclusive,
+		NoLocal:   noLocal,
+		NoWait:    noWait,
+		Args:      args,
+	}
+	ch.consumers.add(consumer, deliveries, config)
 
 	if err := ch.call(req, res); err != nil {
 		ch.consumers.cancel(consumer)
@@ -1228,7 +1324,16 @@ func (ch *Channel) ConsumeWithContext(ctx context.Context, queue, consumer strin
 
 	deliveries := make(chan Delivery)
 
-	ch.consumers.add(consumer, deliveries)
+	config := consumerConfig{
+		Queue:     queue,
+		Consumer:  consumer,
+		AutoAck:   autoAck,
+		Exclusive: exclusive,
+		NoLocal:   noLocal,
+		NoWait:    noWait,
+		Args:      args,
+	}
+	ch.consumers.add(consumer, deliveries, config)
 
 	if err := ch.call(req, res); err != nil {
 		ch.consumers.cancel(consumer)
@@ -1492,7 +1597,10 @@ func (ch *Channel) Publish(exchange, key string, mandatory, immediate bool, msg 
 /*
 PublishWithContext sends a Publishing from the client to an exchange on the server.
 
-NOTE: this function is equivalent to [Channel.Publish]. Context is not honoured.
+If the context is already cancelled when PublishWithContext is called, it
+returns the context error immediately without attempting to publish.  Context
+cancellation after the call has started does not interrupt an in-flight
+Publish, as the underlying I/O is not context-aware.
 
 When you want a single message to be delivered to a single queue, you can
 publish to the default exchange with the routingKey of the queue name.  This is
@@ -1523,8 +1631,13 @@ confirmations start at 1.  Exit when all publishings are confirmed.
 When Publish does not return an error and the channel is in confirm mode, the
 internal counter for DeliveryTags with the first confirmation starts at 1.
 */
-func (ch *Channel) PublishWithContext(_ context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) error {
-	return ch.Publish(exchange, key, mandatory, immediate, msg)
+func (ch *Channel) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return ch.Publish(exchange, key, mandatory, immediate, msg)
+	}
 }
 
 /*
@@ -1583,11 +1696,18 @@ DeferredConfirmation, allowing the caller to wait on the publisher confirmation
 for this message. If the channel has not been put into confirm mode,
 the DeferredConfirmation will be nil.
 
-NOTE: PublishWithDeferredConfirmWithContext is equivalent to its non-context variant. The context passed
-to this function is not honoured.
+If the context is already cancelled when PublishWithDeferredConfirmWithContext is called, it
+returns the context error immediately without attempting to publish.  Context
+cancellation after the call has started does not interrupt an in-flight
+PublishWithDeferredConfirm, as the underlying I/O is not context-aware.
 */
-func (ch *Channel) PublishWithDeferredConfirmWithContext(_ context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) (*DeferredConfirmation, error) {
-	return ch.PublishWithDeferredConfirm(exchange, key, mandatory, immediate, msg)
+func (ch *Channel) PublishWithDeferredConfirmWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) (*DeferredConfirmation, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return ch.PublishWithDeferredConfirm(exchange, key, mandatory, immediate, msg)
+	}
 }
 
 /*
@@ -1790,7 +1910,7 @@ it must be redelivered or dropped.
 
 See also Delivery.Nack
 */
-func (ch *Channel) Nack(tag uint64, multiple bool, requeue bool) error {
+func (ch *Channel) Nack(tag uint64, multiple, requeue bool) error {
 	ch.m.Lock()
 	defer ch.m.Unlock()
 
@@ -1825,4 +1945,198 @@ func (ch *Channel) GetNextPublishSeqNo() uint64 {
 	defer ch.confirms.publishedMut.Unlock()
 
 	return ch.confirms.published + 1
+}
+
+// cleanup closes all the channels and the confirms.
+func (ch *Channel) cleanup() {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
+
+	ch.consumers.close()
+
+	for _, c := range ch.closes {
+		close(c)
+	}
+
+	for _, c := range ch.flows {
+		close(c)
+	}
+
+	for _, c := range ch.returns {
+		close(c)
+	}
+
+	for _, c := range ch.cancels {
+		close(c)
+	}
+
+	for _, c := range ch.recoveryCancels {
+		close(c)
+	}
+
+	ch.recoveryCancels = nil
+	ch.flows = nil
+	ch.closes = nil
+	ch.returns = nil
+	ch.cancels = nil
+
+	if ch.confirms != nil {
+		ch.confirms.Close()
+	}
+
+	ch.noNotify = true
+}
+
+// watchChannel watches the channel for close events and triggers recovery if needed.
+func (ch *Channel) watchChannel() {
+	errCh := ch.NotifyClose(make(chan *Error, 1))
+	go func() {
+		for err := range errCh {
+			if err != nil {
+				Logger.Printf("Channel %d closed unexpectedly: %v", ch.id, err)
+				if ch.connection.Config.Recovery != nil && ch.connection.Config.Recovery.ConnectionRecovery != nil {
+					ch.connection.Config.Recovery.ConnectionRecovery.OnChannelClose(ch, err)
+				}
+			}
+		}
+	}()
+}
+
+// Reconnect initiates automatic channel recovery,
+// re-opens the AMQP channel with the same channel id and configuration,
+// and re-establishes all active publisher confirmations and consumer subscriptions.
+func (ch *Channel) Reconnect() error {
+	if !ch.connection.IsRecoveryEnabled() {
+		return ErrClosed
+	}
+
+	ch.reconnecting.Lock()
+	defer ch.reconnecting.Unlock()
+
+	if !ch.IsClosed() {
+		return nil
+	}
+
+	ch.lifeCycle.SetState(StateReconnecting, nil)
+
+	cancelCh := ch.NotifyRecoveryCancel(make(chan struct{}))
+
+	var err error
+	for i := 0; i < ch.connection.MaxRetryCount(); i++ {
+		// Exit early if Close() was already called
+		select {
+		case <-cancelCh:
+			Logger.Printf("Channel %d recovery aborted: channel closed.", ch.id)
+			return ErrClosed
+		default:
+		}
+
+		Logger.Printf("Channel %d recovery attempt %d of %d", ch.id, i+1, ch.connection.MaxRetryCount())
+		if i > 0 {
+			jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
+
+			// Wait with select to allow immediate interruption of sleep
+			select {
+			case <-cancelCh:
+				Logger.Printf("Channel %d recovery aborted: channel closed during backoff.", ch.id)
+				return ErrClosed
+			case <-time.After(ch.connection.RetryInterval() + jitter):
+			}
+		}
+
+		// 1. Reset client-side state
+		// Reset state under locks to ensure atomicity and prevent data races.
+		// Acquiring destructorM -> m avoids any lock ordering deadlocks.
+		ch.destructorM.Lock()
+		ch.m.Lock()
+		ch.resetState()
+		ch.m.Unlock()
+		ch.destructorM.Unlock()
+
+		// 2. Open a fresh channel on the broker
+		if err = ch.open(); err != nil {
+			Logger.Printf("Channel %d recovery open error: %v", ch.id, err)
+			continue
+		}
+
+		// 3. Perform setup steps. If ANY step fails, we close the channel and retry.
+		if err = ch.setupChannel(); err != nil {
+			Logger.Printf("Channel %d setup failed: %v, closing and retrying...", ch.id, err)
+			ch.setClosed() // Marks closed locally
+			// Send channel.close to the broker so it knows this channel is defunct
+			_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Recovery retry"}, &channelCloseOk{})
+			continue
+		}
+
+		// If we reached here, recovery was 100% successful!
+		Logger.Printf("Channel %d recovery successful", ch.id)
+		ch.lifeCycle.SetState(StateOpen, nil)
+		return nil
+	}
+
+	Logger.Printf("Channel %d recovery exhausted all %d retries", ch.id, ch.connection.MaxRetryCount())
+	ch.setClosed()
+	ch.lifeCycle.SetState(StateClosed, err)
+	return err
+}
+
+// setupChannel performs all channel-level setup steps sequentially.
+// If any of these fail, we return the error immediately so the reconnect loop can try a new channel.
+func (ch *Channel) setupChannel() error {
+	var err error
+	// TODO Re-enable QoS if it was tracked
+
+	// Re-enable confirms if needed
+	if ch.confirming {
+		if err = ch.Confirm(false); err != nil {
+			Logger.Printf("Channel %d recovery Confirm error: %v", ch.id, err)
+			return err
+		}
+	}
+
+	// TODO Recover Topology (Exchanges, Queues, Bindings) here
+
+	// Re-subscribe consumers
+	ch.consumers.Lock()
+	configs := make(map[string]consumerConfig, len(ch.consumers.configs))
+	for tag, config := range ch.consumers.configs {
+		configs[tag] = config
+	}
+	ch.consumers.Unlock()
+	for tag, config := range configs {
+		req := &basicConsume{
+			Queue:       config.Queue,
+			ConsumerTag: tag,
+			NoLocal:     config.NoLocal,
+			NoAck:       config.AutoAck,
+			Exclusive:   config.Exclusive,
+			NoWait:      config.NoWait,
+			Arguments:   config.Args,
+		}
+		res := &basicConsumeOk{}
+		if err = ch.call(req, res); err != nil {
+			Logger.Printf("Channel %d recovery consume error for tag %s: %v", ch.id, tag, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// resetState clears the shutdown flags and re-initializes the internal
+// channels so the AMQP channel can be reused after a successful reconnection.
+// The caller must hold ch.destructorM and ch.m.
+func (ch *Channel) resetState() {
+	ch.closed.Store(false)
+	ch.destructed = false
+
+	ch.errors = make(chan *Error, 1)
+	ch.close = make(chan struct{})
+	ch.rpc = make(chan message)
+
+	if ch.confirms != nil {
+		ch.confirms.reset()
+	}
 }

--- a/vendor/github.com/rabbitmq/amqp091-go/confirms.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/confirms.go
@@ -123,6 +123,21 @@ func (c *confirms) Close() error {
 	return nil
 }
 
+// reset clears any pending deferred confirmations and resets the sequencer
+// state for recovery, while keeping the listeners intact.
+func (c *confirms) reset() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.publishedMut.Lock()
+	defer c.publishedMut.Unlock()
+
+	c.published = 0
+	c.expecting = 1
+	c.deferredConfirmations.Close()
+	c.sequencer = map[uint64]Confirmation{}
+}
+
 type deferredConfirmations struct {
 	m             sync.Mutex
 	confirmations map[uint64]*DeferredConfirmation

--- a/vendor/github.com/rabbitmq/amqp091-go/connection.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/connection.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"reflect"
@@ -28,7 +29,7 @@ const (
 	defaultHeartbeat         = 10 * time.Second
 	defaultConnectionTimeout = 30 * time.Second
 	defaultProduct           = "AMQP 0.9.1 Client"
-	buildVersion             = "1.10.0"
+	buildVersion             = "1.12.0"
 	platform                 = "golang"
 	// Safer default that makes channel leaks a lot easier to spot
 	// before they create operational headaches. See https://github.com/rabbitmq/rabbitmq-server/issues/1593.
@@ -74,6 +75,23 @@ type Config struct {
 	// If Dial is nil, net.DialTimeout with a 30s connection and 30s deadline is
 	// used during TLS and AMQP handshaking.
 	Dial func(network, addr string) (net.Conn, error)
+
+	// Recovery configuration for automatic reconnection.
+	//
+	// Experimental: This is an experimental feature and may be subject to API or
+	// behavioral changes in future releases.
+	//
+	// When a network failure occurs, the connection and all its channels will automatically
+	// attempt to reconnect based on the parameters specified in the Recovery configuration.
+	//
+	// If Recovery is nil, automatic reconnection is disabled.
+	// If Recovery.ReconnectionConfig is nil, a default reconnection configuration (DefaultReconnectionConfig) is used.
+	// If Recovery.ConnectionRecovery is nil, a default connection recovery implementation (DefaultConnectionRecovery) is used.
+	//
+	// During the recovery process, applications can monitor state changes (such as reconnecting
+	// or closed) by registering a listener using `Connection.NotifyStateChange` and
+	// `Channel.NotifyStateChange`.
+	Recovery *Recovery
 }
 
 // NewConnectionProperties creates an amqp.Table to be used as amqp.Config.Properties.
@@ -93,9 +111,13 @@ func NewConnectionProperties() Table {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructor sync.Once  // shutdown once
-	sendM      sync.Mutex // conn writer mutex
-	m          sync.Mutex // struct field mutex
+	destructorM         sync.Mutex // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
+	destructed          bool       // true when the connection has been destructed (teardown is initiated or completed)
+	closeM              sync.Mutex // Mutex for connection close handshake: sending a single connection.close frame to the broker
+	closeInit           bool       // true when a connection close has been initiated (connection.close frame has been or is being sent)
+	sendM               sync.Mutex // conn writer mutex
+	m                   sync.Mutex // struct field mutex
+	recoveryErrorCodesM sync.Mutex // Mutex for protecting RecoverableErrorCodes updates and reads
 
 	conn io.ReadWriteCloser
 
@@ -117,12 +139,19 @@ type Connection struct {
 
 	Config Config // The negotiated Config after connection.open
 
+	url string // Connection URL stored for recovery
+
 	Major      int      // Server's major version
 	Minor      int      // Server's minor version
 	Properties Table    // Server properties
 	Locales    []string // Server locales
 
-	closed int32 // Will be 1 if the connection is closed, 0 otherwise. Should only be accessed as atomic
+	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
+
+	reconnecting sync.Mutex // Mutex for protecting reconnect/recovery operations to ensure serialization and prevent race conditions.
+	lifeCycle    *lifeCycle // The current state of the connection.
+
+	recoveryCancels []chan struct{} // listeners for connection recovery cancellation
 }
 
 type readDeadliner interface {
@@ -204,6 +233,10 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		return nil, err
 	}
 
+	if config.Locale == "" {
+		config.Locale = defaultLocale
+	}
+
 	if config.SASL == nil {
 		if uri.AuthMechanism != nil {
 			for _, identifier := range uri.AuthMechanism {
@@ -280,7 +313,24 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		conn = client
 	}
 
-	return Open(conn, config)
+	if config.Recovery != nil {
+		if config.Recovery.ReconnectionConfig == nil {
+			config.Recovery.ReconnectionConfig = DefaultReconnectionConfig.Clone()
+		} else if config.Recovery.ReconnectionConfig.RecoverableErrorCodes == nil {
+			config.Recovery.ReconnectionConfig.RecoverableErrorCodes = cloneRecoverableErrorCodes(defaultRecoverableErrorCodes)
+		}
+		if config.Recovery.ConnectionRecovery == nil {
+			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{}
+		}
+	}
+
+	c, err := Open(conn, config)
+	if c != nil && c.IsRecoveryEnabled() {
+		c.url = url
+		c.watchConnection()
+	}
+
+	return c, err
 }
 
 /*
@@ -298,9 +348,15 @@ func Open(conn io.ReadWriteCloser, config Config) (*Connection, error) {
 		errors:    make(chan *Error, 1),
 		close:     make(chan struct{}),
 		deadlines: make(chan readDeadliner, 1),
+		Config:    config,
+		lifeCycle: newLifeCycle(),
 	}
 	go c.reader(conn)
-	return c, c.open(config)
+	err := c.open(config)
+	if err == nil {
+		c.lifeCycle.SetState(StateOpen, nil)
+	}
+	return c, err
 }
 
 /*
@@ -356,6 +412,14 @@ func (c *Connection) ConnectionState() tls.ConnectionState {
 	return tls.ConnectionState{}
 }
 
+// NotifyStateChange registers a listener for state changes.
+//
+// It is necessary to continuously consume from the channel passed to NotifyStateChange
+// to avoid blocking internal state dispatch routines and leaking goroutines.
+func (c *Connection) NotifyStateChange(ch chan *StateChanged) {
+	c.lifeCycle.notifyStateChange(ch)
+}
+
 /*
 NotifyClose registers a listener for close events either initiated by an error
 accompanying a connection.close method or by a normal shutdown.
@@ -380,6 +444,40 @@ func (c *Connection) NotifyClose(receiver chan *Error) chan *Error {
 	}
 
 	return receiver
+}
+
+/*
+NotifyRecoveryCancel registers a listener that is notified (via a channel close)
+when connection recovery has been canceled or aborted (for example, when Close()
+or CloseDeadline() is called during an active reconnect process).
+
+The returned channel will be closed immediately if the connection is already closing
+or closed, or when Close() is called.
+*/
+func (c *Connection) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	state := c.lifeCycle.State()
+	if state == StateClosing || state == StateClosed {
+		close(receiver)
+	} else {
+		c.recoveryCancels = append(c.recoveryCancels, receiver)
+	}
+
+	return receiver
+}
+
+// closeRecovery stops any active connection recovery process by notifying
+// and closing all recovery cancellation listeners.
+func (c *Connection) closeRecovery() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	for _, listener := range c.recoveryCancels {
+		close(listener)
+	}
+	c.recoveryCancels = nil
 }
 
 /*
@@ -419,18 +517,38 @@ including the underlying io, Channels, Notify listeners and Channel consumers
 will also be closed.
 */
 func (c *Connection) Close() error {
+	c.closeRecovery() // Stop any active recovery process
+
 	if c.IsClosed() {
 		return ErrClosed
 	}
 
-	defer c.shutdown(nil)
-	return c.call(
-		&connectionClose{
-			ReplyCode: replySuccess,
-			ReplyText: "kthxbai",
-		},
-		&connectionCloseOk{},
-	)
+	c.lifeCycle.SetState(StateClosing, nil)
+
+	var handshakeErr error
+	var initiated bool
+
+	c.closeM.Lock()
+	if !c.closeInit {
+		c.closeInit = true
+		initiated = true
+	}
+	c.closeM.Unlock()
+
+	if initiated {
+		defer c.shutdown(nil)
+		handshakeErr = c.call(
+			&connectionClose{
+				ReplyCode: replySuccess,
+				ReplyText: "kthxbai",
+			},
+			&connectionCloseOk{},
+		)
+	}
+	if !initiated {
+		return ErrClosed
+	}
+	return handshakeErr
 }
 
 // CloseDeadline requests and waits for the response to close this AMQP connection.
@@ -447,24 +565,39 @@ func (c *Connection) Close() error {
 // including the underlying io, Channels, Notify listeners and Channel consumers
 // will also be closed.
 func (c *Connection) CloseDeadline(deadline time.Time) error {
+	c.closeRecovery() // Stop any active recovery process
+
 	if c.IsClosed() {
 		return ErrClosed
 	}
 
-	defer c.shutdown(nil)
+	var handshakeErr error
+	var initiated bool
 
-	err := c.setDeadline(deadline)
-	if err != nil {
-		return err
+	c.closeM.Lock()
+	if !c.closeInit {
+		c.closeInit = true
+		initiated = true
 	}
+	c.closeM.Unlock()
 
-	return c.call(
-		&connectionClose{
-			ReplyCode: replySuccess,
-			ReplyText: "kthxbai",
-		},
-		&connectionCloseOk{},
-	)
+	if initiated {
+		defer c.shutdown(nil)
+		if err := c.setDeadline(deadline); err != nil {
+			return err
+		}
+		handshakeErr = c.call(
+			&connectionClose{
+				ReplyCode: replySuccess,
+				ReplyText: "kthxbai",
+			},
+			&connectionCloseOk{},
+		)
+	}
+	if !initiated {
+		return ErrClosed
+	}
+	return handshakeErr
 }
 
 func (c *Connection) closeWith(err *Error) error {
@@ -472,21 +605,36 @@ func (c *Connection) closeWith(err *Error) error {
 		return ErrClosed
 	}
 
-	defer c.shutdown(err)
+	var handshakeErr error
+	var initiated bool
 
-	return c.call(
-		&connectionClose{
-			ReplyCode: uint16(err.Code),
-			ReplyText: err.Reason,
-		},
-		&connectionCloseOk{},
-	)
+	c.closeM.Lock()
+	if !c.closeInit {
+		c.closeInit = true
+		initiated = true
+	}
+	c.closeM.Unlock()
+
+	if initiated {
+		defer c.shutdown(err)
+		handshakeErr = c.call(
+			&connectionClose{
+				ReplyCode: uint16(err.Code),
+				ReplyText: err.Reason,
+			},
+			&connectionCloseOk{},
+		)
+	}
+	if !initiated {
+		return ErrClosed
+	}
+	return handshakeErr
 }
 
 // IsClosed returns true if the connection is marked as closed, otherwise false
 // is returned.
 func (c *Connection) IsClosed() bool {
-	return atomic.LoadInt32(&c.closed) == 1
+	return c.closed.Load()
 }
 
 // setDeadline is a wrapper to type assert Connection.conn and set an I/O
@@ -598,46 +746,81 @@ func (c *Connection) flush() (err error) {
 }
 
 func (c *Connection) shutdown(err *Error) {
-	atomic.StoreInt32(&c.closed, 1)
+	c.closed.Store(true)
 
-	c.destructor.Do(func() {
-		c.m.Lock()
-		defer c.m.Unlock()
+	c.destructorM.Lock()
+	if c.destructed {
+		c.destructorM.Unlock()
+		return
+	}
+	c.destructed = true
+	defer c.destructorM.Unlock()
 
-		if err != nil {
-			for _, c := range c.closes {
-				c <- err
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if err != nil {
+		for _, listener := range c.closes {
+			select {
+			case listener <- err:
+			default:
+				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
+				go func(listener chan *Error, err *Error) {
+					defer func() {
+						_ = recover() // Gracefully ignore panics if the channel is closed concurrently
+					}()
+					select {
+					case listener <- err:
+					case <-time.After(5 * time.Second):
+						// Give up to avoid leaking the goroutine permanently
+					}
+				}(listener, err)
 			}
-			c.errors <- err
-		}
-		// Shutdown handler goroutine can still receive the result.
-		close(c.errors)
-
-		for _, c := range c.closes {
-			close(c)
 		}
 
-		for _, c := range c.blocks {
-			close(c)
+		select {
+		case c.errors <- err:
+		default:
+		}
+	}
+
+	// Shutdown handler goroutine can still receive the result.
+	close(c.errors)
+
+	if err == nil || !c.IsRecoveryEnabled() || !c.isRecoverable(err) {
+		for _, listener := range c.closes {
+			close(listener)
 		}
 
-		// Shutdown the channel, but do not use closeChannel() as it calls
-		// releaseChannel() which requires the connection lock.
-		//
-		// Ranging over c.channels and calling releaseChannel() that mutates
-		// c.channels is racy - see commit 6063341 for an example.
-		for _, ch := range c.channels {
-			ch.shutdown(err)
+		for _, block := range c.blocks {
+			close(block)
 		}
+	}
 
-		c.conn.Close()
-		// reader exit
-		close(c.close)
+	// Shutdown the channel, but do not use closeChannel() as it calls
+	// releaseChannel() which requires the connection lock.
+	//
+	// Ranging over c.channels and calling releaseChannel() that mutates
+	// c.channels is racy - see commit 6063341 for an example.
+	for _, ch := range c.channels {
+		ch.shutdown(err)
+	}
 
+	c.conn.Close()
+	// reader exit
+	close(c.close)
+
+	if err == nil || !c.IsRecoveryEnabled() || !c.isRecoverable(err) {
 		c.channels = nil
 		c.allocator = nil
 		c.noNotify = true
-	})
+
+		var e error
+		if err != nil {
+			e = fmt.Errorf("%w", err) // preserve the original error type for assertions
+		}
+		c.lifeCycle.SetState(StateClosed, e)
+	}
 }
 
 // All methods sent to the connection channel should be synchronous so we
@@ -675,7 +858,6 @@ func (c *Connection) dispatch0(f frame) {
 				return
 			case c.rpc <- m:
 			}
-
 		}
 	case *heartbeatFrame:
 		// kthx - all reads reset our deadline.  so we can drop this
@@ -755,7 +937,6 @@ func (c *Connection) reader(r io.Reader) {
 
 	for {
 		frame, err := frames.ReadFrame()
-
 		if err != nil {
 			c.shutdown(&Error{Code: FrameError, Reason: err.Error()})
 			return
@@ -776,7 +957,7 @@ func (c *Connection) reader(r io.Reader) {
 
 // Ensures that at least one frame is being sent at the tuned interval with a
 // jitter tolerance of 1s
-func (c *Connection) heartbeater(interval time.Duration, done chan *Error) {
+func (c *Connection) heartbeater(interval time.Duration, done chan struct{}) {
 	const maxServerHeartbeatsInFlight = 3
 
 	var sendTicks <-chan time.Time
@@ -884,6 +1065,13 @@ func (c *Connection) openChannel() (*Channel, error) {
 		c.releaseChannel(ch)
 		return nil, err
 	}
+
+	ch.lifeCycle.SetState(StateOpen, nil)
+
+	if c.IsRecoveryEnabled() {
+		ch.watchChannel()
+	}
+
 	return ch, nil
 }
 
@@ -899,13 +1087,17 @@ func (c *Connection) closeChannel(ch *Channel, e *Error) {
 Channel opens a unique, concurrent server channel to process the bulk of AMQP
 messages.  Any error from methods on this receiver will render the receiver
 invalid and a new Channel should be opened.
+
+Channels are not thread-safe. To avoid unexpected behavior, do not share
+a single Channel instance between multiple goroutines. Concurrent calls
+to Channel methods may result in race conditions or unpredictable outcomes.
 */
 func (c *Connection) Channel() (*Channel, error) {
 	return c.openChannel()
 }
 
 func (c *Connection) call(req message, res ...message) error {
-	// Special case for when the protocol header frame is sent insted of a
+	// Special case for when the protocol header frame is sent instead of a
 	// request method
 	if req != nil {
 		if err := c.send(&methodFrame{ChannelId: 0, Method: req}); err != nil {
@@ -1029,6 +1221,11 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 	c.Config.ChannelMax = minUInt16(c.Config.ChannelMax, maxChannelMax)
 
 	c.allocator = newAllocator(1, int(c.Config.ChannelMax))
+	// Reserve all the channels that are already open
+	// This is to avoid allocating the same channel ID after a reconnection
+	for id := range c.channels {
+		c.allocator.reserve(int(id))
+	}
 
 	c.m.Unlock()
 
@@ -1044,7 +1241,7 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 
 	// "The client should start sending heartbeats after receiving a
 	// Connection.Tune method"
-	go c.heartbeater(c.Config.Heartbeat/2, c.NotifyClose(make(chan *Error, 1)))
+	go c.heartbeater(c.Config.Heartbeat/2, c.close)
 
 	if err := c.send(&methodFrame{
 		ChannelId: 0,
@@ -1169,4 +1366,279 @@ func pick(client, server int) int {
 		return max(client, server)
 	}
 	return min(client, server)
+}
+
+// cleanup releases registered resources and performs final teardown of the connection.
+func (c *Connection) cleanup() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	for _, listener := range c.closes {
+		close(listener)
+	}
+
+	for _, block := range c.blocks {
+		close(block)
+	}
+
+	for _, ch := range c.channels {
+		ch.cleanup()
+	}
+
+	for _, listener := range c.recoveryCancels {
+		close(listener)
+	}
+
+	c.recoveryCancels = nil
+	c.channels = nil
+	c.allocator = nil
+	c.noNotify = true
+}
+
+// watchConnection watches the connection for close events and triggers recovery if needed.
+func (c *Connection) watchConnection() {
+	errCh := c.NotifyClose(make(chan *Error, 1))
+	go func() {
+		for err := range errCh {
+			if err != nil {
+				Logger.Printf("Connection closed unexpectedly: %v", err)
+				if c.Config.Recovery != nil && c.Config.Recovery.ConnectionRecovery != nil {
+					c.Config.Recovery.ConnectionRecovery.OnConnectionClose(c, err)
+				}
+			}
+		}
+	}()
+}
+
+// Reconnect establishes a new socket connection, replaces the existing closed/closing connection,
+// and recovers both connection and channel states.
+// It performs a retry loop to dial the broker, negotiate the AMQP handshake, and recover all
+// active channels and their registered consumers sequentially.
+func (c *Connection) Reconnect() error {
+	if !c.IsRecoveryEnabled() {
+		return ErrClosed
+	}
+
+	c.reconnecting.Lock()
+	defer c.reconnecting.Unlock()
+
+	if !c.IsClosed() {
+		return nil
+	}
+
+	c.lifeCycle.SetState(StateReconnecting, nil)
+
+	cancelCh := c.NotifyRecoveryCancel(make(chan struct{}))
+
+	var err error
+	for i := 0; i < c.MaxRetryCount(); i++ {
+		Logger.Printf("Connection recovery attempt %d of %d", i+1, c.MaxRetryCount())
+		jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
+
+		// Wait with select to allow immediate interruption of sleep
+		select {
+		case <-cancelCh:
+			Logger.Printf("Connection recovery aborted: connection closed during backoff.")
+			return ErrClosed
+		case <-time.After(c.RetryInterval() + jitter):
+		}
+
+		// Re-dial
+		var conn net.Conn
+		dialer := c.Config.Dial
+		if dialer == nil {
+			dialer = DefaultDial(defaultConnectionTimeout)
+		}
+
+		// We need to parse URL to get addr
+		var uri URI
+		uri, err = ParseURI(c.url)
+		if err != nil {
+			Logger.Printf("Connection recovery failed to parse URI: %v", err)
+			return err
+		}
+		addr := net.JoinHostPort(uri.Host, strconv.FormatInt(int64(uri.Port), 10))
+
+		conn, err = dialer("tcp", addr)
+		if err != nil {
+			Logger.Printf("Connection recovery dial error: %v", err)
+			continue
+		}
+
+		// TLS handshake if needed
+		if uri.Scheme == "amqps" {
+			client := tls.Client(conn, c.Config.TLSClientConfig)
+			if err = client.Handshake(); err != nil {
+				Logger.Printf("Connection recovery TLS handshake error: %v", err)
+				conn.Close()
+				continue
+			}
+			conn = client
+		}
+
+		// Reset state and swap connection under locks to ensure atomicity
+		// and prevent data races with concurrent readers/writers.
+		// Acquiring destructorM -> closeM -> m avoids any lock ordering deadlocks.
+		c.destructorM.Lock()
+		c.closeM.Lock()
+		c.m.Lock()
+
+		// Swap the connection
+		c.conn = conn
+		c.writer = &writer{bufio.NewWriter(conn)}
+
+		c.resetState()
+
+		c.m.Unlock()
+		c.closeM.Unlock()
+		c.destructorM.Unlock()
+
+		go c.reader(conn)
+
+		if err = c.open(c.Config); err != nil {
+			Logger.Printf("Connection recovery open error: %v", err)
+			conn.Close()
+			continue
+		}
+
+		// Reconnect channels
+		c.m.Lock()
+		channels := make([]*Channel, 0, len(c.channels))
+		for _, ch := range c.channels {
+			channels = append(channels, ch)
+		}
+		c.m.Unlock()
+
+		for _, ch := range channels {
+			if err = ch.Reconnect(); err != nil {
+				Logger.Printf("Connection recovery failed to reconnect channel %d: %v", ch.id, err)
+				conn.Close()
+				break
+			}
+		}
+
+		// This error check is for retrying when the channels are not able to reconnect
+		if err != nil {
+			continue
+		}
+
+		Logger.Printf("Connection recovery successful")
+		c.lifeCycle.SetState(StateOpen, nil)
+		return nil
+	}
+
+	Logger.Printf("Connection recovery exhausted all %d retries", c.MaxRetryCount())
+	if c.conn != nil {
+		c.conn.Close()
+	}
+	c.closed.Store(true)
+	c.lifeCycle.SetState(StateClosed, err)
+
+	return err
+}
+
+// resetState clears the shutdown and close flags and re-initializes the internal
+// channels so the connection can be reused after a successful reconnection.
+// The caller must hold c.destructorM, c.closeM and c.m.
+func (c *Connection) resetState() {
+	c.closed.Store(false)
+	c.destructed = false
+	c.closeInit = false
+
+	c.errors = make(chan *Error, 1)
+	c.close = make(chan struct{})
+
+	// Re-create the rpc channel so we don't read stale messages from the previous connection
+	c.rpc = make(chan message)
+}
+
+// IsRecoveryEnabled checks if the recovery is enabled.
+func (c *Connection) IsRecoveryEnabled() bool {
+	if c == nil {
+		return false
+	}
+	c.closeM.Lock()
+	closedOrClosing := c.closeInit
+	c.closeM.Unlock()
+	if closedOrClosing {
+		return false
+	}
+	return c.Config.Recovery != nil &&
+		c.Config.Recovery.ReconnectionConfig != nil &&
+		c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0 &&
+		len(c.GetRecoverableErrorCodes()) > 0
+}
+
+// isRecoverable returns true if the given error is recoverable based on RecoverableErrorCodes.
+func (c *Connection) isRecoverable(err *Error) bool {
+	if !c.IsRecoveryEnabled() {
+		return false
+	}
+	if err == nil {
+		return true
+	}
+	for _, code := range c.GetRecoverableErrorCodes() {
+		if err.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// GetRecoverableErrorCodes returns a copy of the recoverable error codes.
+func (c *Connection) GetRecoverableErrorCodes() []int {
+	if c == nil {
+		return nil
+	}
+	c.recoveryErrorCodesM.Lock()
+	defer c.recoveryErrorCodesM.Unlock()
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return nil
+	}
+
+	return cloneRecoverableErrorCodes(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes)
+}
+
+// MaxRetryCount returns the maximum number of retries if recovery is enabled, otherwise returns 0.
+func (c *Connection) MaxRetryCount() int {
+	if c.IsRecoveryEnabled() {
+		return c.Config.Recovery.ReconnectionConfig.MaxRetryCount
+	}
+	return 0
+}
+
+// RetryInterval returns the interval between retries if recovery is enabled, otherwise returns 0.
+func (c *Connection) RetryInterval() time.Duration {
+	if c.IsRecoveryEnabled() {
+		return c.Config.Recovery.ReconnectionConfig.RetryInterval
+	}
+	return 0
+}
+
+// SetRecoverableErrorCodes sets the list of error codes that trigger recovery.
+func (c *Connection) SetRecoverableErrorCodes(codes []int) error {
+	if c == nil {
+		return ErrClosed
+	}
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return ErrRecoveryNotEnabled
+	}
+	c.recoveryErrorCodesM.Lock()
+	defer c.recoveryErrorCodesM.Unlock()
+	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = codes
+	return nil
+}
+
+// AddRecoverableErrorCodes adds one or more error codes to the list of recoverable error codes.
+func (c *Connection) AddRecoverableErrorCodes(codes ...int) error {
+	if c == nil {
+		return ErrClosed
+	}
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return ErrRecoveryNotEnabled
+	}
+	c.recoveryErrorCodesM.Lock()
+	defer c.recoveryErrorCodesM.Unlock()
+	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = append(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes, codes...)
+	return nil
 }

--- a/vendor/github.com/rabbitmq/amqp091-go/consumers.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/consumers.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 )
 
-var consumerSeq uint64
+var consumerSeq atomic.Uint64
 
 const consumerTagLengthMax = 0xFF // see writeShortstr
 
@@ -23,7 +23,7 @@ func uniqueConsumerTag() string {
 func commandNameBasedUniqueConsumerTag(commandName string) string {
 	tagPrefix := "ctag-"
 	tagInfix := commandName
-	tagSuffix := "-" + strconv.FormatUint(atomic.AddUint64(&consumerSeq, 1), 10)
+	tagSuffix := "-" + strconv.FormatUint(consumerSeq.Add(1), 10)
 
 	if len(tagPrefix)+len(tagInfix)+len(tagSuffix) > consumerTagLengthMax {
 		tagInfix = "streadway/amqp"
@@ -32,7 +32,25 @@ func commandNameBasedUniqueConsumerTag(commandName string) string {
 	return tagPrefix + tagInfix + tagSuffix
 }
 
+// consumerConfig stores the configuration parameters used when a consumer is registered.
+// This is required during automatic connection and channel recovery. When a network connection
+// drops and is restored, the library uses these stored parameters to automatically re-register
+// and resume all consumers on the recovered channels seamlessly, preserving the subscriber topology.
+type consumerConfig struct {
+	Queue     string
+	Consumer  string
+	AutoAck   bool
+	Exclusive bool
+	NoLocal   bool
+	NoWait    bool
+	Args      Table
+}
+
 type consumerBuffers map[string]chan *Delivery
+
+// consumerConfigs maps unique consumer tags to their respective consumerConfig parameters,
+// facilitating the automatic re-registration of all consumers during channel recovery.
+type consumerConfigs map[string]consumerConfig
 
 // Concurrent type that manages the consumerTag ->
 // ingress consumerBuffer mapping
@@ -42,12 +60,14 @@ type consumers struct {
 
 	sync.Mutex // protects below
 	chans      consumerBuffers
+	configs    consumerConfigs
 }
 
 func makeConsumers() *consumers {
 	return &consumers{
-		closed: make(chan struct{}),
-		chans:  make(consumerBuffers),
+		closed:  make(chan struct{}),
+		chans:   make(consumerBuffers),
+		configs: make(consumerConfigs),
 	}
 }
 
@@ -55,7 +75,7 @@ func (subs *consumers) buffer(in chan *Delivery, out chan Delivery) {
 	defer close(out)
 	defer subs.Done()
 
-	var inflight = in
+	inflight := in
 	var queue []*Delivery
 
 	for delivery := range in {
@@ -109,7 +129,7 @@ func (subs *consumers) buffer(in chan *Delivery, out chan Delivery) {
 }
 
 // On key conflict, close the previous channel.
-func (subs *consumers) add(tag string, consumer chan Delivery) {
+func (subs *consumers) add(tag string, consumer chan Delivery, config consumerConfig) {
 	subs.Lock()
 	defer subs.Unlock()
 
@@ -119,6 +139,7 @@ func (subs *consumers) add(tag string, consumer chan Delivery) {
 
 	in := make(chan *Delivery)
 	subs.chans[tag] = in
+	subs.configs[tag] = config
 
 	subs.Add(1)
 	go subs.buffer(in, consumer)
@@ -132,6 +153,7 @@ func (subs *consumers) cancel(tag string) (found bool) {
 
 	if found {
 		delete(subs.chans, tag)
+		delete(subs.configs, tag)
 		close(ch)
 	}
 
@@ -146,6 +168,7 @@ func (subs *consumers) close() {
 
 	for tag, ch := range subs.chans {
 		delete(subs.chans, tag)
+		delete(subs.configs, tag)
 		close(ch)
 	}
 

--- a/vendor/github.com/rabbitmq/amqp091-go/delivery.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/delivery.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var errDeliveryNotInitialized = errors.New("delivery not initialized")
+var ErrDeliveryNotInitialized = errors.New("delivery not initialized. Channel is probably closed")
 
 // Acknowledger notifies the server of successful or failed consumption of
 // deliveries via identifier found in the Delivery.DeliveryTag field.
@@ -18,7 +18,7 @@ var errDeliveryNotInitialized = errors.New("delivery not initialized")
 // Applications can provide mock implementations in tests of Delivery handlers.
 type Acknowledger interface {
 	Ack(tag uint64, multiple bool) error
-	Nack(tag uint64, multiple bool, requeue bool) error
+	Nack(tag uint64, multiple, requeue bool) error
 	Reject(tag uint64, requeue bool) error
 }
 
@@ -122,7 +122,7 @@ delivery that is not automatically acknowledged.
 */
 func (d Delivery) Ack(multiple bool) error {
 	if d.Acknowledger == nil {
-		return errDeliveryNotInitialized
+		return ErrDeliveryNotInitialized
 	}
 	return d.Acknowledger.Ack(d.DeliveryTag, multiple)
 }
@@ -142,7 +142,7 @@ delivery that is not automatically acknowledged.
 */
 func (d Delivery) Reject(requeue bool) error {
 	if d.Acknowledger == nil {
-		return errDeliveryNotInitialized
+		return ErrDeliveryNotInitialized
 	}
 	return d.Acknowledger.Reject(d.DeliveryTag, requeue)
 }
@@ -167,7 +167,7 @@ delivery that is not automatically acknowledged.
 */
 func (d Delivery) Nack(multiple, requeue bool) error {
 	if d.Acknowledger == nil {
-		return errDeliveryNotInitialized
+		return ErrDeliveryNotInitialized
 	}
 	return d.Acknowledger.Nack(d.DeliveryTag, multiple, requeue)
 }

--- a/vendor/github.com/rabbitmq/amqp091-go/lifecycle.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/lifecycle.go
@@ -1,0 +1,190 @@
+package amqp091
+
+import (
+	"fmt"
+	"sync"
+)
+
+// LifeCycleState defines the connection or channel state type.
+type LifeCycleState byte
+
+const (
+	// StateOpen represents a connection or channel that is active and open.
+	StateOpen LifeCycleState = iota
+	// StateReconnecting represents a connection or channel that is actively undergoing automatic recovery.
+	StateReconnecting
+	// StateClosing represents a connection or channel that is in the process of closing down.
+	StateClosing
+	// StateClosed represents a connection or channel that is fully closed and shut down.
+	StateClosed
+)
+
+func (s LifeCycleState) String() string {
+	switch s {
+	case StateOpen:
+		return "open"
+	case StateReconnecting:
+		return "reconnecting"
+	case StateClosing:
+		return "closing"
+	case StateClosed:
+		return "closed"
+	default:
+		return "unknown"
+	}
+}
+
+// StateChanged defines the connection or channel life cycle transitions.
+type StateChanged struct {
+	From LifeCycleState
+	To   LifeCycleState
+	Err  error // Stores the error when transitioning to StateClosed
+}
+
+func (s StateChanged) String() string {
+	if s.Err != nil {
+		return fmt.Sprintf("From: %s, To: %s, Error: %v", s.From, s.To, s.Err)
+	}
+	return fmt.Sprintf("From: %s, To: %s", s.From, s.To)
+}
+
+type stateListener struct {
+	ch      chan *StateChanged
+	queue   []*StateChanged
+	sending bool
+}
+
+// enqueue appends a state change to the listener's bounded queue using a sliding window.
+// If the queue size exceeds maxQueueSize, the oldest state change is dropped.
+// This assumes the caller holds the lifeCycle mutex.
+func (sl *stateListener) enqueue(sc *StateChanged) {
+	const maxQueueSize = 50
+	if len(sl.queue) < maxQueueSize {
+		sl.queue = append(sl.queue, sc)
+	} else {
+		sl.queue[0] = nil // Allow GC to reclaim the dropped element
+		sl.queue = append(sl.queue[1:], sc)
+	}
+}
+
+// lifeCycle is the lifecycle of the connection or channel.
+//
+// The listener framework manages state change notifications for registered channels.
+// Key characteristics:
+//   - Multiple listeners can register concurrently via NotifyStateChange.
+//   - Each listener operates concurrently and is isolated from others; a blocked or slow
+//     listener will not block other listeners or the main SetState() execution.
+//   - Strict FIFO ordering of state transitions is guaranteed for each listener by spawning
+//     at most one dedicated delivery goroutine per listener.
+//   - Memory usage is strictly bounded by a sliding-window queue per listener (maxQueueSize = 50).
+//   - Listener channels are cleanly closed as soon as the final StateClosed transition is sent.
+type lifeCycle struct {
+	state     LifeCycleState   // The current state of the connection or channel.
+	listeners []*stateListener // The registered state change listeners.
+	mutex     *sync.Mutex      // The mutex to protect the state changes.
+}
+
+func newLifeCycle() *lifeCycle {
+	return &lifeCycle{
+		state: StateClosed,
+		mutex: &sync.Mutex{},
+	}
+}
+
+func (l *lifeCycle) State() LifeCycleState {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.state
+}
+
+func (l *lifeCycle) SetState(value LifeCycleState, err error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.state == value {
+		return
+	}
+
+	oldState := l.state
+	l.state = value
+
+	sc := &StateChanged{
+		From: oldState,
+		To:   value,
+		Err:  err,
+	}
+
+	for _, listener := range l.listeners {
+		listener.enqueue(sc)
+		if !listener.sending {
+			listener.sending = true
+			go l.deliverToListener(listener)
+		}
+	}
+}
+
+func (l *lifeCycle) deliverToListener(listener *stateListener) {
+	for {
+		l.mutex.Lock()
+		if len(listener.queue) == 0 {
+			listener.sending = false
+			l.mutex.Unlock()
+			return
+		}
+		sc := listener.queue[0]
+		listener.queue[0] = nil // Allow GC to reclaim the popped element
+		listener.queue = listener.queue[1:]
+		ch := listener.ch
+		l.mutex.Unlock()
+
+		ch <- sc
+
+		// If the transition is to StateClosed, this is the terminal state.
+		// We can safely close the channel now because:
+		// 1. No more states will be appended (StateClosed is final).
+		// 2. The StateClosed notification was just successfully sent.
+		if sc.To == StateClosed {
+			l.mutex.Lock()
+			close(ch)
+			l.removeListener(listener)
+			l.mutex.Unlock()
+			return
+		}
+	}
+}
+
+func (l *lifeCycle) removeListener(listener *stateListener) {
+	for i, lis := range l.listeners {
+		if lis == listener {
+			copy(l.listeners[i:], l.listeners[i+1:])
+			l.listeners[len(l.listeners)-1] = nil // Allow GC to reclaim the listener
+			l.listeners = l.listeners[:len(l.listeners)-1]
+			break
+		}
+	}
+}
+
+func (l *lifeCycle) notifyStateChange(channel chan *StateChanged) {
+	if channel == nil {
+		return
+	}
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	// If the connection/channel is already closed, close the channel immediately.
+	if l.state == StateClosed {
+		close(channel)
+		return
+	}
+
+	// Prevent duplicate registration of the same channel.
+	for _, lis := range l.listeners {
+		if lis.ch == channel {
+			return
+		}
+	}
+
+	listener := &stateListener{
+		ch: channel,
+	}
+	l.listeners = append(l.listeners, listener)
+}

--- a/vendor/github.com/rabbitmq/amqp091-go/log.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/log.go
@@ -5,7 +5,7 @@
 package amqp091
 
 type Logging interface {
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 var Logger Logging = NullLogger{}
@@ -16,8 +16,7 @@ func SetLogger(logger Logging) {
 	Logger = logger
 }
 
-type NullLogger struct {
-}
+type NullLogger struct{}
 
-func (l NullLogger) Printf(format string, v ...interface{}) {
+func (l NullLogger) Printf(format string, v ...any) {
 }

--- a/vendor/github.com/rabbitmq/amqp091-go/read.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/read.go
@@ -140,7 +140,7 @@ func readTimestamp(r io.Reader) (v time.Time, err error) {
 }
 
 /*
-'A': []interface{}
+'A': any
 'D': Decimal
 'F': Table
 'I': int32
@@ -152,11 +152,13 @@ func readTimestamp(r io.Reader) (v time.Time, err error) {
 'd': float64
 'f': float32
 'l': int64
+'i': uint32
 's': int16
+'u': uint16
 't': bool
 'x': []byte
 */
-func readField(r io.Reader) (v interface{}, err error) {
+func readField(r io.Reader) (v any, err error) {
 	var typ byte
 	if err = binary.Read(r, binary.BigEndian, &typ); err != nil {
 		return
@@ -200,6 +202,20 @@ func readField(r io.Reader) (v interface{}, err error) {
 
 	case 'l':
 		var value int64
+		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
+			return
+		}
+		return value, nil
+
+	case 'u':
+		var value uint16
+		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
+			return
+		}
+		return value, nil
+
+	case 'i':
+		var value uint32
 		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
 			return
 		}
@@ -269,13 +285,13 @@ func readTable(r io.Reader) (table Table, err error) {
 		return
 	}
 
-	nested.Write([]byte(str))
+	nested.WriteString(str)
 
 	table = make(Table)
 
 	for nested.Len() > 0 {
 		var key string
-		var value interface{}
+		var value any
 
 		if key, err = readShortstr(&nested); err != nil {
 			return
@@ -291,11 +307,8 @@ func readTable(r io.Reader) (table Table, err error) {
 	return
 }
 
-func readArray(r io.Reader) ([]interface{}, error) {
-	var (
-		size uint32
-		err  error
-	)
+func readArray(r io.Reader) (arr []any, err error) {
+	var size uint32
 
 	if err = binary.Read(r, binary.BigEndian, &size); err != nil {
 		return nil, err
@@ -303,8 +316,7 @@ func readArray(r io.Reader) ([]interface{}, error) {
 
 	var (
 		lim   = &io.LimitedReader{R: r, N: int64(size)}
-		arr   []interface{}
-		field interface{}
+		field any
 	)
 
 	for {
@@ -330,91 +342,101 @@ func (r *reader) parseHeaderFrame(channel uint16, size uint32) (frame frame, err
 		ChannelId: channel,
 	}
 
-	if err = binary.Read(r.r, binary.BigEndian, &hf.ClassId); err != nil {
+	lim := &io.LimitedReader{R: r.r, N: int64(size)}
+
+	if err = binary.Read(lim, binary.BigEndian, &hf.ClassId); err != nil {
 		return
 	}
 
-	if err = binary.Read(r.r, binary.BigEndian, &hf.weight); err != nil {
+	if err = binary.Read(lim, binary.BigEndian, &hf.weight); err != nil {
 		return
 	}
 
-	if err = binary.Read(r.r, binary.BigEndian, &hf.Size); err != nil {
+	if err = binary.Read(lim, binary.BigEndian, &hf.Size); err != nil {
 		return
 	}
 
 	var flags uint16
 
-	if err = binary.Read(r.r, binary.BigEndian, &flags); err != nil {
+	if err = binary.Read(lim, binary.BigEndian, &flags); err != nil {
 		return
 	}
 
 	if hasProperty(flags, flagContentType) {
-		if hf.Properties.ContentType, err = readShortstr(r.r); err != nil {
+		if hf.Properties.ContentType, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagContentEncoding) {
-		if hf.Properties.ContentEncoding, err = readShortstr(r.r); err != nil {
+		if hf.Properties.ContentEncoding, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagHeaders) {
-		if hf.Properties.Headers, err = readTable(r.r); err != nil {
+		if hf.Properties.Headers, err = readTable(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagDeliveryMode) {
-		if err = binary.Read(r.r, binary.BigEndian, &hf.Properties.DeliveryMode); err != nil {
+		if err = binary.Read(lim, binary.BigEndian, &hf.Properties.DeliveryMode); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagPriority) {
-		if err = binary.Read(r.r, binary.BigEndian, &hf.Properties.Priority); err != nil {
+		if err = binary.Read(lim, binary.BigEndian, &hf.Properties.Priority); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagCorrelationId) {
-		if hf.Properties.CorrelationId, err = readShortstr(r.r); err != nil {
+		if hf.Properties.CorrelationId, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagReplyTo) {
-		if hf.Properties.ReplyTo, err = readShortstr(r.r); err != nil {
+		if hf.Properties.ReplyTo, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagExpiration) {
-		if hf.Properties.Expiration, err = readShortstr(r.r); err != nil {
+		if hf.Properties.Expiration, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagMessageId) {
-		if hf.Properties.MessageId, err = readShortstr(r.r); err != nil {
+		if hf.Properties.MessageId, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagTimestamp) {
-		if hf.Properties.Timestamp, err = readTimestamp(r.r); err != nil {
+		if hf.Properties.Timestamp, err = readTimestamp(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagType) {
-		if hf.Properties.Type, err = readShortstr(r.r); err != nil {
+		if hf.Properties.Type, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagUserId) {
-		if hf.Properties.UserId, err = readShortstr(r.r); err != nil {
+		if hf.Properties.UserId, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagAppId) {
-		if hf.Properties.AppId, err = readShortstr(r.r); err != nil {
+		if hf.Properties.AppId, err = readShortstr(lim); err != nil {
 			return
 		}
 	}
 	if hasProperty(flags, flagReserved1) {
-		if hf.Properties.reserved1, err = readShortstr(r.r); err != nil {
+		if hf.Properties.reserved1, err = readShortstr(lim); err != nil {
+			return
+		}
+	}
+
+	// Drain any bytes remaining in the frame payload that were not consumed
+	// by property parsing (e.g. padding added by other AMQP implementations).
+	if lim.N > 0 {
+		if _, err = io.CopyN(io.Discard, lim, lim.N); err != nil {
 			return
 		}
 	}
@@ -435,7 +457,7 @@ func (r *reader) parseBodyFrame(channel uint16, size uint32) (frame frame, err e
 	return bf, nil
 }
 
-var errHeartbeatPayload = errors.New("Heartbeats should not have a payload")
+var errHeartbeatPayload = errors.New("heartbeats should not have a payload")
 
 func (r *reader) parseHeartbeatFrame(channel uint16, size uint32) (frame frame, err error) {
 	hf := &heartbeatFrame{

--- a/vendor/github.com/rabbitmq/amqp091-go/recovery.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/recovery.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+package amqp091
+
+import (
+	"net/url"
+	"time"
+)
+
+const (
+	// DefaultMaxRetryCount is the default maximum number of retries for recovery.
+	DefaultMaxRetryCount = 5
+
+	// DefaultRetryInterval is the default interval between retries for recovery.
+	DefaultRetryInterval = 5 * time.Second
+)
+
+var (
+	// defaultRecoverableErrorCodes contains the default exception codes that trigger recovery.
+	defaultRecoverableErrorCodes = []int{ConnectionForced, InternalError}
+
+	// DefaultReconnectionConfig is the default reconnection config settings.
+	DefaultReconnectionConfig = &ReconnectionConfig{
+		MaxRetryCount:         DefaultMaxRetryCount,
+		RetryInterval:         DefaultRetryInterval,
+		RecoverableErrorCodes: cloneRecoverableErrorCodes(defaultRecoverableErrorCodes),
+	}
+)
+
+// cloneRecoverableErrorCodes returns a clone of given RecoverableErrorCodes slice.
+// It is used to avoid modifying the original slice.
+func cloneRecoverableErrorCodes(inRecoverableErrorCodes []int) []int {
+	if inRecoverableErrorCodes == nil {
+		return nil
+	}
+	codes := make([]int, len(inRecoverableErrorCodes))
+	copy(codes, inRecoverableErrorCodes)
+	return codes
+}
+
+// ReconnectionConfig is the configuration for the reconnection.
+type ReconnectionConfig struct {
+	MaxRetryCount         int           // The maximum number of retries.
+	RetryInterval         time.Duration // The interval between retries.
+	RecoverableErrorCodes []int         // The error codes that trigger recovery.
+}
+
+// Clone returns a deep copy of the ReconnectionConfig.
+func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
+	if rc == nil {
+		return nil
+	}
+	return &ReconnectionConfig{
+		MaxRetryCount:         rc.MaxRetryCount,
+		RetryInterval:         rc.RetryInterval,
+		RecoverableErrorCodes: cloneRecoverableErrorCodes(rc.RecoverableErrorCodes),
+	}
+}
+
+// ConnectionRecovery is the interface for the connection recovery.
+//
+// The err parameter in OnConnectionClose and OnChannelClose provides the reason
+// why the connection or channel was closed. Under the hood, DefaultConnectionRecovery
+// performs conditional recovery based on RecoverableErrorCodes. You can also customize
+// the list of recoverable errors dynamically using Connection.SetRecoverableErrorCodes and
+// Connection.AddRecoverableErrorCodes, or use custom implementations of this interface to
+// perform more advanced logic, log errors to external monitoring systems (e.g., Prometheus),
+// or trigger alerts.
+type ConnectionRecovery interface {
+	OnConnectionClose(conn *Connection, err *Error) // Called when the connection is closed.
+	OnChannelClose(ch *Channel, err *Error)         // Called when the channel is closed.
+}
+
+// Recovery is the configuration for the recovery.
+type Recovery struct {
+	ReconnectionConfig *ReconnectionConfig // The configuration for the reconnection.
+	ConnectionRecovery ConnectionRecovery  // The implementation of the connection recovery.
+}
+
+// DefaultConnectionRecovery is the default implementation of the connection recovery.
+type DefaultConnectionRecovery struct{}
+
+func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Error) {
+	Logger.Printf("Connection closed with error: %v", err)
+
+	parsedURL, err1 := url.Parse(conn.url)
+	if err1 != nil {
+		Logger.Printf("Error parsing connection URL: %v", err1)
+		return
+	}
+
+	if !conn.IsRecoveryEnabled() {
+		Logger.Printf("Connection %s recovery is not enabled, skipping reconnect. ", parsedURL.Redacted())
+		return
+	}
+
+	if !conn.isRecoverable(err) {
+		code := 0
+		if err != nil {
+			code = err.Code
+		}
+		Logger.Printf("Connection %s closed with non-recoverable error code %d, skipping reconnect.", parsedURL.Redacted(), code)
+		return
+	}
+
+	Logger.Printf("Initiating connection recovery for %s.", parsedURL.Redacted())
+	// Reconnect connection
+	if err := conn.Reconnect(); err != nil {
+		Logger.Printf("Connection %s recovery failed: %v.", parsedURL.Redacted(), err)
+		conn.cleanup()
+	}
+}
+
+func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
+	Logger.Printf("Channel %d closed with error: %v", ch.id, err)
+	if !ch.connection.IsRecoveryEnabled() {
+		Logger.Printf("Channel %d recovery is not enabled, skipping reconnect.", ch.id)
+		return
+	}
+
+	if ch.connection.IsClosed() {
+		Logger.Printf("Connection is closed, letting connection recovery handle channel %d.", ch.id)
+		return
+	}
+
+	if !ch.connection.isRecoverable(err) {
+		code := 0
+		if err != nil {
+			code = err.Code
+		}
+		Logger.Printf("Channel %d closed with non-recoverable error code %d, skipping reconnect.", ch.id, code)
+		return
+	}
+
+	Logger.Printf("Initiating channel %d recovery", ch.id)
+	// Reconnect channel
+	if err := ch.Reconnect(); err != nil {
+		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)
+		ch.cleanup()
+	}
+}

--- a/vendor/github.com/rabbitmq/amqp091-go/return.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/return.go
@@ -25,7 +25,7 @@ type Return struct {
 	DeliveryMode    uint8     // queue implementation use - non-persistent (1) or persistent (2)
 	Priority        uint8     // queue implementation use - 0 to 9
 	CorrelationId   string    // application use - correlation identifier
-	ReplyTo         string    // application use - address to to reply to (ex: RPC)
+	ReplyTo         string    // application use - address to reply to (ex: RPC)
 	Expiration      string    // implementation use - message expiration spec
 	MessageId       string    // application use - message identifier
 	Timestamp       time.Time // application use - message timestamp

--- a/vendor/github.com/rabbitmq/amqp091-go/spec091.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/spec091.go
@@ -84,7 +84,6 @@ func (msg *connectionStart) wait() bool {
 }
 
 func (msg *connectionStart) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.VersionMajor); err != nil {
 		return
 	}
@@ -107,7 +106,6 @@ func (msg *connectionStart) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionStart) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.VersionMajor); err != nil {
 		return
 	}
@@ -145,7 +143,6 @@ func (msg *connectionStartOk) wait() bool {
 }
 
 func (msg *connectionStartOk) write(w io.Writer) (err error) {
-
 	if err = writeTable(w, msg.ClientProperties); err != nil {
 		return
 	}
@@ -166,7 +163,6 @@ func (msg *connectionStartOk) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionStartOk) read(r io.Reader) (err error) {
-
 	if msg.ClientProperties, err = readTable(r); err != nil {
 		return
 	}
@@ -199,7 +195,6 @@ func (msg *connectionSecure) wait() bool {
 }
 
 func (msg *connectionSecure) write(w io.Writer) (err error) {
-
 	if err = writeLongstr(w, msg.Challenge); err != nil {
 		return
 	}
@@ -208,7 +203,6 @@ func (msg *connectionSecure) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionSecure) read(r io.Reader) (err error) {
-
 	if msg.Challenge, err = readLongstr(r); err != nil {
 		return
 	}
@@ -229,7 +223,6 @@ func (msg *connectionSecureOk) wait() bool {
 }
 
 func (msg *connectionSecureOk) write(w io.Writer) (err error) {
-
 	if err = writeLongstr(w, msg.Response); err != nil {
 		return
 	}
@@ -238,7 +231,6 @@ func (msg *connectionSecureOk) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionSecureOk) read(r io.Reader) (err error) {
-
 	if msg.Response, err = readLongstr(r); err != nil {
 		return
 	}
@@ -261,7 +253,6 @@ func (msg *connectionTune) wait() bool {
 }
 
 func (msg *connectionTune) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.ChannelMax); err != nil {
 		return
 	}
@@ -278,7 +269,6 @@ func (msg *connectionTune) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionTune) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.ChannelMax); err != nil {
 		return
 	}
@@ -309,7 +299,6 @@ func (msg *connectionTuneOk) wait() bool {
 }
 
 func (msg *connectionTuneOk) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.ChannelMax); err != nil {
 		return
 	}
@@ -326,7 +315,6 @@ func (msg *connectionTuneOk) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionTuneOk) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.ChannelMax); err != nil {
 		return
 	}
@@ -408,7 +396,6 @@ func (msg *connectionOpenOk) wait() bool {
 }
 
 func (msg *connectionOpenOk) write(w io.Writer) (err error) {
-
 	if err = writeShortstr(w, msg.reserved1); err != nil {
 		return
 	}
@@ -417,7 +404,6 @@ func (msg *connectionOpenOk) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionOpenOk) read(r io.Reader) (err error) {
-
 	if msg.reserved1, err = readShortstr(r); err != nil {
 		return
 	}
@@ -441,7 +427,6 @@ func (msg *connectionClose) wait() bool {
 }
 
 func (msg *connectionClose) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.ReplyCode); err != nil {
 		return
 	}
@@ -461,7 +446,6 @@ func (msg *connectionClose) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionClose) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.ReplyCode); err != nil {
 		return
 	}
@@ -480,8 +464,7 @@ func (msg *connectionClose) read(r io.Reader) (err error) {
 	return
 }
 
-type connectionCloseOk struct {
-}
+type connectionCloseOk struct{}
 
 func (msg *connectionCloseOk) id() (uint16, uint16) {
 	return 10, 51
@@ -492,12 +475,10 @@ func (msg *connectionCloseOk) wait() bool {
 }
 
 func (msg *connectionCloseOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *connectionCloseOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -514,7 +495,6 @@ func (msg *connectionBlocked) wait() bool {
 }
 
 func (msg *connectionBlocked) write(w io.Writer) (err error) {
-
 	if err = writeShortstr(w, msg.Reason); err != nil {
 		return
 	}
@@ -523,7 +503,6 @@ func (msg *connectionBlocked) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionBlocked) read(r io.Reader) (err error) {
-
 	if msg.Reason, err = readShortstr(r); err != nil {
 		return
 	}
@@ -531,8 +510,7 @@ func (msg *connectionBlocked) read(r io.Reader) (err error) {
 	return
 }
 
-type connectionUnblocked struct {
-}
+type connectionUnblocked struct{}
 
 func (msg *connectionUnblocked) id() (uint16, uint16) {
 	return 10, 61
@@ -543,12 +521,10 @@ func (msg *connectionUnblocked) wait() bool {
 }
 
 func (msg *connectionUnblocked) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *connectionUnblocked) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -566,7 +542,6 @@ func (msg *connectionUpdateSecret) wait() bool {
 }
 
 func (msg *connectionUpdateSecret) write(w io.Writer) (err error) {
-
 	if err = writeLongstr(w, msg.NewSecret); err != nil {
 		return
 	}
@@ -579,7 +554,6 @@ func (msg *connectionUpdateSecret) write(w io.Writer) (err error) {
 }
 
 func (msg *connectionUpdateSecret) read(r io.Reader) (err error) {
-
 	if msg.NewSecret, err = readLongstr(r); err != nil {
 		return
 	}
@@ -591,8 +565,7 @@ func (msg *connectionUpdateSecret) read(r io.Reader) (err error) {
 	return
 }
 
-type connectionUpdateSecretOk struct {
-}
+type connectionUpdateSecretOk struct{}
 
 func (msg *connectionUpdateSecretOk) id() (uint16, uint16) {
 	return 10, 71
@@ -603,12 +576,10 @@ func (msg *connectionUpdateSecretOk) wait() bool {
 }
 
 func (msg *connectionUpdateSecretOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *connectionUpdateSecretOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -625,7 +596,6 @@ func (msg *channelOpen) wait() bool {
 }
 
 func (msg *channelOpen) write(w io.Writer) (err error) {
-
 	if err = writeShortstr(w, msg.reserved1); err != nil {
 		return
 	}
@@ -634,7 +604,6 @@ func (msg *channelOpen) write(w io.Writer) (err error) {
 }
 
 func (msg *channelOpen) read(r io.Reader) (err error) {
-
 	if msg.reserved1, err = readShortstr(r); err != nil {
 		return
 	}
@@ -655,7 +624,6 @@ func (msg *channelOpenOk) wait() bool {
 }
 
 func (msg *channelOpenOk) write(w io.Writer) (err error) {
-
 	if err = writeLongstr(w, msg.reserved1); err != nil {
 		return
 	}
@@ -664,7 +632,6 @@ func (msg *channelOpenOk) write(w io.Writer) (err error) {
 }
 
 func (msg *channelOpenOk) read(r io.Reader) (err error) {
-
 	if msg.reserved1, err = readLongstr(r); err != nil {
 		return
 	}
@@ -762,7 +729,6 @@ func (msg *channelClose) wait() bool {
 }
 
 func (msg *channelClose) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.ReplyCode); err != nil {
 		return
 	}
@@ -782,7 +748,6 @@ func (msg *channelClose) write(w io.Writer) (err error) {
 }
 
 func (msg *channelClose) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.ReplyCode); err != nil {
 		return
 	}
@@ -801,8 +766,7 @@ func (msg *channelClose) read(r io.Reader) (err error) {
 	return
 }
 
-type channelCloseOk struct {
-}
+type channelCloseOk struct{}
 
 func (msg *channelCloseOk) id() (uint16, uint16) {
 	return 20, 41
@@ -813,12 +777,10 @@ func (msg *channelCloseOk) wait() bool {
 }
 
 func (msg *channelCloseOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *channelCloseOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -917,8 +879,7 @@ func (msg *exchangeDeclare) read(r io.Reader) (err error) {
 	return
 }
 
-type exchangeDeclareOk struct {
-}
+type exchangeDeclareOk struct{}
 
 func (msg *exchangeDeclareOk) id() (uint16, uint16) {
 	return 40, 11
@@ -929,12 +890,10 @@ func (msg *exchangeDeclareOk) wait() bool {
 }
 
 func (msg *exchangeDeclareOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *exchangeDeclareOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -999,8 +958,7 @@ func (msg *exchangeDelete) read(r io.Reader) (err error) {
 	return
 }
 
-type exchangeDeleteOk struct {
-}
+type exchangeDeleteOk struct{}
 
 func (msg *exchangeDeleteOk) id() (uint16, uint16) {
 	return 40, 21
@@ -1011,12 +969,10 @@ func (msg *exchangeDeleteOk) wait() bool {
 }
 
 func (msg *exchangeDeleteOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *exchangeDeleteOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -1098,8 +1054,7 @@ func (msg *exchangeBind) read(r io.Reader) (err error) {
 	return
 }
 
-type exchangeBindOk struct {
-}
+type exchangeBindOk struct{}
 
 func (msg *exchangeBindOk) id() (uint16, uint16) {
 	return 40, 31
@@ -1110,12 +1065,10 @@ func (msg *exchangeBindOk) wait() bool {
 }
 
 func (msg *exchangeBindOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *exchangeBindOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -1197,8 +1150,7 @@ func (msg *exchangeUnbind) read(r io.Reader) (err error) {
 	return
 }
 
-type exchangeUnbindOk struct {
-}
+type exchangeUnbindOk struct{}
 
 func (msg *exchangeUnbindOk) id() (uint16, uint16) {
 	return 40, 51
@@ -1209,12 +1161,10 @@ func (msg *exchangeUnbindOk) wait() bool {
 }
 
 func (msg *exchangeUnbindOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *exchangeUnbindOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -1321,7 +1271,6 @@ func (msg *queueDeclareOk) wait() bool {
 }
 
 func (msg *queueDeclareOk) write(w io.Writer) (err error) {
-
 	if err = writeShortstr(w, msg.Queue); err != nil {
 		return
 	}
@@ -1337,7 +1286,6 @@ func (msg *queueDeclareOk) write(w io.Writer) (err error) {
 }
 
 func (msg *queueDeclareOk) read(r io.Reader) (err error) {
-
 	if msg.Queue, err = readShortstr(r); err != nil {
 		return
 	}
@@ -1430,8 +1378,7 @@ func (msg *queueBind) read(r io.Reader) (err error) {
 	return
 }
 
-type queueBindOk struct {
-}
+type queueBindOk struct{}
 
 func (msg *queueBindOk) id() (uint16, uint16) {
 	return 50, 21
@@ -1442,12 +1389,10 @@ func (msg *queueBindOk) wait() bool {
 }
 
 func (msg *queueBindOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *queueBindOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -1468,7 +1413,6 @@ func (msg *queueUnbind) wait() bool {
 }
 
 func (msg *queueUnbind) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.reserved1); err != nil {
 		return
 	}
@@ -1491,7 +1435,6 @@ func (msg *queueUnbind) write(w io.Writer) (err error) {
 }
 
 func (msg *queueUnbind) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.reserved1); err != nil {
 		return
 	}
@@ -1513,8 +1456,7 @@ func (msg *queueUnbind) read(r io.Reader) (err error) {
 	return
 }
 
-type queueUnbindOk struct {
-}
+type queueUnbindOk struct{}
 
 func (msg *queueUnbindOk) id() (uint16, uint16) {
 	return 50, 51
@@ -1525,12 +1467,10 @@ func (msg *queueUnbindOk) wait() bool {
 }
 
 func (msg *queueUnbindOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *queueUnbindOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -1602,7 +1542,6 @@ func (msg *queuePurgeOk) wait() bool {
 }
 
 func (msg *queuePurgeOk) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.MessageCount); err != nil {
 		return
 	}
@@ -1611,7 +1550,6 @@ func (msg *queuePurgeOk) write(w io.Writer) (err error) {
 }
 
 func (msg *queuePurgeOk) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.MessageCount); err != nil {
 		return
 	}
@@ -1699,7 +1637,6 @@ func (msg *queueDeleteOk) wait() bool {
 }
 
 func (msg *queueDeleteOk) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.MessageCount); err != nil {
 		return
 	}
@@ -1708,7 +1645,6 @@ func (msg *queueDeleteOk) write(w io.Writer) (err error) {
 }
 
 func (msg *queueDeleteOk) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.MessageCount); err != nil {
 		return
 	}
@@ -1771,8 +1707,7 @@ func (msg *basicQos) read(r io.Reader) (err error) {
 	return
 }
 
-type basicQosOk struct {
-}
+type basicQosOk struct{}
 
 func (msg *basicQosOk) id() (uint16, uint16) {
 	return 60, 11
@@ -1783,12 +1718,10 @@ func (msg *basicQosOk) wait() bool {
 }
 
 func (msg *basicQosOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *basicQosOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -1894,7 +1827,6 @@ func (msg *basicConsumeOk) wait() bool {
 }
 
 func (msg *basicConsumeOk) write(w io.Writer) (err error) {
-
 	if err = writeShortstr(w, msg.ConsumerTag); err != nil {
 		return
 	}
@@ -1903,7 +1835,6 @@ func (msg *basicConsumeOk) write(w io.Writer) (err error) {
 }
 
 func (msg *basicConsumeOk) read(r io.Reader) (err error) {
-
 	if msg.ConsumerTag, err = readShortstr(r); err != nil {
 		return
 	}
@@ -1970,7 +1901,6 @@ func (msg *basicCancelOk) wait() bool {
 }
 
 func (msg *basicCancelOk) write(w io.Writer) (err error) {
-
 	if err = writeShortstr(w, msg.ConsumerTag); err != nil {
 		return
 	}
@@ -1979,7 +1909,6 @@ func (msg *basicCancelOk) write(w io.Writer) (err error) {
 }
 
 func (msg *basicCancelOk) read(r io.Reader) (err error) {
-
 	if msg.ConsumerTag, err = readShortstr(r); err != nil {
 		return
 	}
@@ -2091,7 +2020,6 @@ func (msg *basicReturn) setContent(props properties, body []byte) {
 }
 
 func (msg *basicReturn) write(w io.Writer) (err error) {
-
 	if err = binary.Write(w, binary.BigEndian, msg.ReplyCode); err != nil {
 		return
 	}
@@ -2110,7 +2038,6 @@ func (msg *basicReturn) write(w io.Writer) (err error) {
 }
 
 func (msg *basicReturn) read(r io.Reader) (err error) {
-
 	if err = binary.Read(r, binary.BigEndian, &msg.ReplyCode); err != nil {
 		return
 	}
@@ -2358,7 +2285,6 @@ func (msg *basicGetEmpty) wait() bool {
 }
 
 func (msg *basicGetEmpty) write(w io.Writer) (err error) {
-
 	if err = writeShortstr(w, msg.reserved1); err != nil {
 		return
 	}
@@ -2367,7 +2293,6 @@ func (msg *basicGetEmpty) write(w io.Writer) (err error) {
 }
 
 func (msg *basicGetEmpty) read(r io.Reader) (err error) {
-
 	if msg.reserved1, err = readShortstr(r); err != nil {
 		return
 	}
@@ -2541,8 +2466,7 @@ func (msg *basicRecover) read(r io.Reader) (err error) {
 	return
 }
 
-type basicRecoverOk struct {
-}
+type basicRecoverOk struct{}
 
 func (msg *basicRecoverOk) id() (uint16, uint16) {
 	return 60, 111
@@ -2553,12 +2477,10 @@ func (msg *basicRecoverOk) wait() bool {
 }
 
 func (msg *basicRecoverOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *basicRecoverOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -2614,8 +2536,7 @@ func (msg *basicNack) read(r io.Reader) (err error) {
 	return
 }
 
-type txSelect struct {
-}
+type txSelect struct{}
 
 func (msg *txSelect) id() (uint16, uint16) {
 	return 90, 10
@@ -2626,17 +2547,14 @@ func (msg *txSelect) wait() bool {
 }
 
 func (msg *txSelect) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *txSelect) read(r io.Reader) (err error) {
-
 	return
 }
 
-type txSelectOk struct {
-}
+type txSelectOk struct{}
 
 func (msg *txSelectOk) id() (uint16, uint16) {
 	return 90, 11
@@ -2647,17 +2565,14 @@ func (msg *txSelectOk) wait() bool {
 }
 
 func (msg *txSelectOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *txSelectOk) read(r io.Reader) (err error) {
-
 	return
 }
 
-type txCommit struct {
-}
+type txCommit struct{}
 
 func (msg *txCommit) id() (uint16, uint16) {
 	return 90, 20
@@ -2668,17 +2583,14 @@ func (msg *txCommit) wait() bool {
 }
 
 func (msg *txCommit) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *txCommit) read(r io.Reader) (err error) {
-
 	return
 }
 
-type txCommitOk struct {
-}
+type txCommitOk struct{}
 
 func (msg *txCommitOk) id() (uint16, uint16) {
 	return 90, 21
@@ -2689,17 +2601,14 @@ func (msg *txCommitOk) wait() bool {
 }
 
 func (msg *txCommitOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *txCommitOk) read(r io.Reader) (err error) {
-
 	return
 }
 
-type txRollback struct {
-}
+type txRollback struct{}
 
 func (msg *txRollback) id() (uint16, uint16) {
 	return 90, 30
@@ -2710,17 +2619,14 @@ func (msg *txRollback) wait() bool {
 }
 
 func (msg *txRollback) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *txRollback) read(r io.Reader) (err error) {
-
 	return
 }
 
-type txRollbackOk struct {
-}
+type txRollbackOk struct{}
 
 func (msg *txRollbackOk) id() (uint16, uint16) {
 	return 90, 31
@@ -2731,12 +2637,10 @@ func (msg *txRollbackOk) wait() bool {
 }
 
 func (msg *txRollbackOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *txRollbackOk) read(r io.Reader) (err error) {
-
 	return
 }
 
@@ -2777,8 +2681,7 @@ func (msg *confirmSelect) read(r io.Reader) (err error) {
 	return
 }
 
-type confirmSelectOk struct {
-}
+type confirmSelectOk struct{}
 
 func (msg *confirmSelectOk) id() (uint16, uint16) {
 	return 85, 11
@@ -2789,12 +2692,10 @@ func (msg *confirmSelectOk) wait() bool {
 }
 
 func (msg *confirmSelectOk) write(w io.Writer) (err error) {
-
 	return
 }
 
 func (msg *confirmSelectOk) read(r io.Reader) (err error) {
-
 	return
 }
 

--- a/vendor/github.com/rabbitmq/amqp091-go/types.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/types.go
@@ -23,6 +23,21 @@ const (
 	ExchangeHeaders = "headers"
 )
 
+// MIME types constants
+const (
+	MimeTextPlain                  = "text/plain"
+	MimeApplicationJSON            = "application/json"
+	MimeApplicationOctetStream     = "application/octet-stream"
+	MimeApplicationXML             = "application/xml"
+	MimeTextXML                    = "text/xml"
+	MimeApplicationProtobuf        = "application/protobuf"
+	MimeApplicationXProtobuf       = "application/x-protobuf"
+	MimeApplicationMsgPack         = "application/msgpack"
+	MimeApplicationAvro            = "application/avro"
+	MimeApplicationCloudEventsJSON = "application/cloudevents+json"
+	MimeApplicationFormURLEncoded  = "application/x-www-form-urlencoded"
+)
+
 var (
 	// ErrClosed is returned when the channel or connection is not open
 	ErrClosed = &Error{Code: ChannelError, Reason: "channel/connection is not open"}
@@ -63,12 +78,17 @@ var (
 
 	// ErrFieldType is returned when writing a message containing a Go type unsupported by AMQP.
 	ErrFieldType = &Error{Code: SyntaxError, Reason: "unsupported table field type"}
+
+	// ErrRecoveryNotEnabled is returned when recovery operations are attempted but recovery is not enabled.
+	ErrRecoveryNotEnabled = &Error{Code: ChannelError, Reason: "recovery is not enabled on this connection"}
 )
 
 // internal errors used inside the library
 var (
 	errInvalidTypeAssertion = &Error{Code: InternalError, Reason: "type assertion unsuccessful", Server: false, Recover: true}
 )
+
+var _ error = (*Error)(nil)
 
 // Error captures the code and reason a channel or connection has been closed
 // by the server.
@@ -88,8 +108,52 @@ func newError(code uint16, text string) *Error {
 	}
 }
 
-func (e Error) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("Exception (%d) Reason: %q", e.Code, e.Reason)
+}
+
+// Recoverable returns true if the error can be recovered by retrying later or with different parameters.
+// Returns the value of the Recover field.
+func (e *Error) Recoverable() bool {
+	return e.Recover
+}
+
+// Temporary returns true if the error can be recovered by retrying later with the same parameters.
+//
+// The following are the codes which might be resolved by retry without external
+// action, according to the AMQP 0.91 spec
+// (https://www.rabbitmq.com/amqp-0-9-1-reference.html#constants). The quotations
+// are from that page.
+//
+// ContentTooLarge (311)
+// "The client attempted to transfer content larger than the server could
+// accept at the present time. The client may retry at a later time."
+//
+// ConnectionForced (320)
+// "An operator intervened to close the connection for some reason. The
+// client may retry at some later date."
+func (e *Error) Temporary() bool {
+	// amqp.Error has a Recover field which sounds like it should mean "retryable".
+	// But it actually means "can be recovered by retrying later or with different
+	// parameters," which is not what we want. The error codes for which Recover is
+	// true, defined in the isSoftExceptionCode function, including things
+	// like NotFound and AccessRefused, which require outside action.
+	switch e.Code {
+	case ContentTooLarge:
+		return true
+
+	case ConnectionForced:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// GoString returns a longer description of the error than .Error() including all fields.
+func (e *Error) GoString() string {
+	return fmt.Sprintf("Exception=%d, Reason=%q, Recover=%v, Server=%v",
+		e.Code, e.Reason, e.Recover, e.Server)
 }
 
 // Used by header frames to capture routing and header information
@@ -100,7 +164,7 @@ type properties struct {
 	DeliveryMode    uint8     // queue implementation use - Transient (1) or Persistent (2)
 	Priority        uint8     // queue implementation use - 0 to 9
 	CorrelationId   string    // application use - correlation identifier
-	ReplyTo         string    // application use - address to to reply to (ex: RPC)
+	ReplyTo         string    // application use - address to reply to (ex: RPC)
 	Expiration      string    // implementation use - message expiration spec
 	MessageId       string    // application use - message identifier
 	Timestamp       time.Time // application use - message timestamp
@@ -180,11 +244,11 @@ type Publishing struct {
 	DeliveryMode    uint8  // Transient (0 or 1) or Persistent (2)
 	Priority        uint8  // 0 to 9
 	CorrelationId   string // correlation identifier
-	ReplyTo         string // address to to reply to (ex: RPC)
+	ReplyTo         string // address to reply to (ex: RPC)
 	// Expiration represents the message TTL in milliseconds. A value of "0"
 	// indicates that the message will immediately expire if the message arrives
 	// at its destination and the message is not directly handled by a consumer
-	// that currently has the capacatity to do so. If you wish the message to
+	// that currently has the capacity to do so. If you wish the message to
 	// not expire on its own, set this value to any ttl value, empty string or
 	// use the corresponding constants NeverExpire and ImmediatelyExpire. This
 	// does not influence queue configured TTL values.
@@ -326,13 +390,15 @@ const (
 //	int16
 //	int32
 //	int64
+//	uint16
+//	uint32
 //	nil
 //	string
 //	time.Time
 //	amqp.Decimal
 //	amqp.Table
 //	[]byte
-//	[]interface{} - containing above types
+//	[]any - containing above types
 //
 // Functions taking a table will immediately fail when the table contains a
 // value of an unsupported type.
@@ -343,14 +409,14 @@ const (
 // Use a type assertion when reading values from a table for type conversion.
 //
 // RabbitMQ expects int32 for integer values.
-type Table map[string]interface{}
+type Table map[string]any
 
-func validateField(f interface{}) error {
+func validateField(f any) error {
 	switch fv := f.(type) {
-	case nil, bool, byte, int8, int, int16, int32, int64, float32, float64, string, []byte, Decimal, time.Time:
+	case nil, bool, byte, int8, int, int16, int32, int64, uint16, uint32, float32, float64, string, []byte, Decimal, time.Time:
 		return nil
 
-	case []interface{}:
+	case []any:
 		for _, v := range fv {
 			if err := validateField(v); err != nil {
 				return fmt.Errorf("in array %s", err)

--- a/vendor/github.com/rabbitmq/amqp091-go/uri.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/uri.go
@@ -14,8 +14,10 @@ import (
 	"strings"
 )
 
-var errURIScheme = errors.New("AMQP scheme must be either 'amqp://' or 'amqps://'")
-var errURIWhitespace = errors.New("URI must not contain whitespace")
+var (
+	errURIScheme     = errors.New("AMQP scheme must be either 'amqp://' or 'amqps://'")
+	errURIWhitespace = errors.New("URI must not contain whitespace")
+)
 
 var schemePorts = map[string]int{
 	"amqp":  5672,
@@ -164,7 +166,7 @@ func ParseURI(uri string) (URI, error) {
 	if params.Has("channel_max") {
 		value, err := strconv.ParseUint(params.Get("channel_max"), 10, 16)
 		if err != nil {
-			return builder, fmt.Errorf("connection_timeout is not an integer: %v", err)
+			return builder, fmt.Errorf("channel_max is not an uint16: %v", err)
 		}
 		builder.ChannelMax = uint16(value)
 	}

--- a/vendor/github.com/rabbitmq/amqp091-go/write.go
+++ b/vendor/github.com/rabbitmq/amqp091-go/write.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"time"
@@ -90,44 +91,44 @@ func (f *headerFrame) write(w io.Writer) (err error) {
 
 	var mask uint16
 
-	if len(f.Properties.ContentType) > 0 {
-		mask = mask | flagContentType
+	if f.Properties.ContentType != "" {
+		mask |= flagContentType
 	}
-	if len(f.Properties.ContentEncoding) > 0 {
-		mask = mask | flagContentEncoding
+	if f.Properties.ContentEncoding != "" {
+		mask |= flagContentEncoding
 	}
-	if f.Properties.Headers != nil && len(f.Properties.Headers) > 0 {
-		mask = mask | flagHeaders
+	if len(f.Properties.Headers) > 0 {
+		mask |= flagHeaders
 	}
 	if f.Properties.DeliveryMode > 0 {
-		mask = mask | flagDeliveryMode
+		mask |= flagDeliveryMode
 	}
 	if f.Properties.Priority > 0 {
-		mask = mask | flagPriority
+		mask |= flagPriority
 	}
-	if len(f.Properties.CorrelationId) > 0 {
-		mask = mask | flagCorrelationId
+	if f.Properties.CorrelationId != "" {
+		mask |= flagCorrelationId
 	}
-	if len(f.Properties.ReplyTo) > 0 {
-		mask = mask | flagReplyTo
+	if f.Properties.ReplyTo != "" {
+		mask |= flagReplyTo
 	}
-	if len(f.Properties.Expiration) > 0 {
-		mask = mask | flagExpiration
+	if f.Properties.Expiration != "" {
+		mask |= flagExpiration
 	}
-	if len(f.Properties.MessageId) > 0 {
-		mask = mask | flagMessageId
+	if f.Properties.MessageId != "" {
+		mask |= flagMessageId
 	}
 	if !f.Properties.Timestamp.IsZero() {
-		mask = mask | flagTimestamp
+		mask |= flagTimestamp
 	}
-	if len(f.Properties.Type) > 0 {
-		mask = mask | flagType
+	if f.Properties.Type != "" {
+		mask |= flagType
 	}
-	if len(f.Properties.UserId) > 0 {
-		mask = mask | flagUserId
+	if f.Properties.UserId != "" {
+		mask |= flagUserId
 	}
-	if len(f.Properties.AppId) > 0 {
-		mask = mask | flagAppId
+	if f.Properties.AppId != "" {
+		mask |= flagAppId
 	}
 
 	if err = binary.Write(&payload, binary.BigEndian, mask); err != nil {
@@ -224,7 +225,6 @@ func writeFrame(w io.Writer, typ uint8, channel uint16, payload []byte) (err err
 		byte((size & 0x0000ff00) >> 8),
 		byte((size & 0x000000ff) >> 0),
 	})
-
 	if err != nil {
 		return
 	}
@@ -243,7 +243,7 @@ func writeFrame(w io.Writer, typ uint8, channel uint16, payload []byte) (err err
 func writeShortstr(w io.Writer, s string) (err error) {
 	b := []byte(s)
 
-	var length = uint8(len(b))
+	length := uint8(len(b))
 
 	if err = binary.Write(w, binary.BigEndian, length); err != nil {
 		return
@@ -259,7 +259,7 @@ func writeShortstr(w io.Writer, s string) (err error) {
 func writeLongstr(w io.Writer, s string) (err error) {
 	b := []byte(s)
 
-	var length = uint32(len(b))
+	length := uint32(len(b))
 
 	if err = binary.Write(w, binary.BigEndian, length); err != nil {
 		return
@@ -273,7 +273,7 @@ func writeLongstr(w io.Writer, s string) (err error) {
 }
 
 /*
-'A': []interface{}
+'A': []any
 'D': Decimal
 'F': Table
 'I': int32
@@ -285,11 +285,13 @@ func writeLongstr(w io.Writer, s string) (err error) {
 'd': float64
 'f': float32
 'l': int64
+'i': uint32
 's': int16
+'u': uint16
 't': bool
 'x': []byte
 */
-func writeField(w io.Writer, value interface{}) (err error) {
+func writeField(w io.Writer, value any) (err error) {
 	var buf [9]byte
 	var enc []byte
 
@@ -333,6 +335,16 @@ func writeField(w io.Writer, value interface{}) (err error) {
 		binary.BigEndian.PutUint64(buf[1:9], uint64(v))
 		enc = buf[:9]
 
+	case uint16:
+		buf[0] = 'u'
+		binary.BigEndian.PutUint16(buf[1:3], v)
+		enc = buf[:3]
+
+	case uint32:
+		buf[0] = 'i'
+		binary.BigEndian.PutUint32(buf[1:5], v)
+		enc = buf[:5]
+
 	case float32:
 		buf[0] = 'f'
 		binary.BigEndian.PutUint32(buf[1:5], math.Float32bits(v))
@@ -354,7 +366,7 @@ func writeField(w io.Writer, value interface{}) (err error) {
 		binary.BigEndian.PutUint32(buf[1:5], uint32(len(v)))
 		enc = append(buf[:5], []byte(v)...)
 
-	case []interface{}: // field-array
+	case []any: // field-array
 		buf[0] = 'A'
 
 		sec := new(bytes.Buffer)
@@ -410,17 +422,23 @@ func writeField(w io.Writer, value interface{}) (err error) {
 	return
 }
 
+// writeTable serializes a Table to the given writer.
+// It writes each key-value pair and returns the serialized data as a longstr.
 func writeTable(w io.Writer, table Table) (err error) {
 	var buf bytes.Buffer
 
 	for key, val := range table {
 		if err = writeShortstr(&buf, key); err != nil {
-			return
+			return fmt.Errorf("writing key %q: %w", key, err)
 		}
 		if err = writeField(&buf, val); err != nil {
-			return
+			return fmt.Errorf("writing value for key %q: %w", key, err)
 		}
 	}
 
-	return writeLongstr(w, buf.String())
+	if err := writeLongstr(w, buf.String()); err != nil {
+		return fmt.Errorf("writing final long string: %w", err)
+	}
+
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,3 @@
-# github.com/rabbitmq/amqp091-go v1.10.0
+# github.com/rabbitmq/amqp091-go v1.12.0
 ## explicit; go 1.20
 github.com/rabbitmq/amqp091-go


### PR DESCRIPTION
- Raises the minimum Go version to 1.26 (latest stable) and bumps `rabbitmq/amqp091-go` from v1.10.0 to v1.12.0 (re-vendored).
- Adopts stdlib helpers the new minimum allows: `slices.Clone` (resolving the existing TODO in `connection.go`), `maps.Copy`, `math/rand/v2`, and range-over-int.
- CI now reads the Go version from `go.mod` (`setup-go@v5` / `checkout@v4`) so future Go bumps don't require workflow edits.

No behavioral changes; full suite including docker integration tests passes under `-race`.