### PR TITLE
Don't Fatalf when publisher recovery fails

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -120,21 +120,29 @@ func NewPublisher(conn *Conn, optionFuncs ...func(*PublisherOptions)) (*Publishe
 		})
 	}
 
-	go func() {
-		for err := range publisher.reconnectErrCh {
-			publisher.options.Logger.Infof("successful publisher recovery from: %v", err)
-			err := publisher.startup()
-			if err != nil {
-				publisher.options.Logger.Fatalf("error on startup for publisher after cancel or close: %v", err)
-				publisher.options.Logger.Fatalf("publisher closing, unable to recover")
-				return
-			}
-			publisher.startReturnHandler()
-			publisher.startPublishHandler()
+	go publisher.restartOnReconnect(func() error {
+		// a failed declaration closes the channel, so the channel manager
+		// will reconnect and signal us again
+		if err := publisher.startup(); err != nil {
+			return err
 		}
-	}()
+		publisher.startReturnHandler()
+		publisher.startPublishHandler()
+		return nil
+	})
 
 	return publisher, nil
+}
+
+func (publisher *Publisher) restartOnReconnect(restart func() error) {
+	for reconnectErr := range publisher.reconnectErrCh {
+		publisher.options.Logger.Infof("successful publisher recovery from: %v", reconnectErr)
+		if err := restart(); err != nil {
+			publisher.options.Logger.Errorf(
+				"error restarting publisher after reconnect, waiting for next reconnect: %v", err,
+			)
+		}
+	}
 }
 
 func (publisher *Publisher) startup() error {

--- a/publish_test.go
+++ b/publish_test.go
@@ -1,0 +1,32 @@
+package rabbitmq
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPublisherRestartContinuesAfterError(t *testing.T) {
+	reconnectErrCh := make(chan error, 2)
+	reconnectErrCh <- errors.New("first reconnect")
+	reconnectErrCh <- errors.New("second reconnect")
+	close(reconnectErrCh)
+
+	publisher := &Publisher{
+		reconnectErrCh: reconnectErrCh,
+		options: PublisherOptions{
+			Logger: simpleLogF(t.Logf),
+		},
+	}
+	restarts := 0
+	publisher.restartOnReconnect(func() error {
+		restarts++
+		if restarts == 1 {
+			return errors.New("broker failed during exchange declaration")
+		}
+		return nil
+	})
+
+	if restarts != 2 {
+		t.Fatalf("restart attempts = %d, want 2", restarts)
+	}
+}


### PR DESCRIPTION
- The publisher's reconnect loop called `Logger.Fatalf` when redeclaring the exchange failed after a reconnect, which `os.Exit(1)`s the host process with the default logger.
- It now logs the error and waits for the next reconnect signal instead, matching the consumer recovery behavior from #221 (a failed declaration closes the channel, so the channel manager reconnects and signals again).
- Adds a unit test covering a failed restart followed by a successful one.