### PR TITLE
Surface confirm-mode errors instead of dropping them

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -297,3 +297,36 @@ func TestPublisherConfirmationsInOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestNotifyPublishSurfacesConfirmError(t *testing.T) {
+	connStr := prepareDockerTest(t)
+	conn := waitForHealthyAmqp(t, connStr)
+	defer conn.Close()
+
+	var logMu sync.Mutex
+	var logs []string
+	logger := simpleLogF(func(format string, args ...interface{}) {
+		logMu.Lock()
+		defer logMu.Unlock()
+		logs = append(logs, fmt.Sprintf(format, args...))
+	})
+
+	publisher, err := NewPublisher(conn, WithPublisherOptionsLogger(logger))
+	if err != nil {
+		t.Fatal("error creating publisher", err)
+	}
+
+	// confirm mode can't be established on the closed channel
+	publisher.Close()
+
+	publisher.NotifyPublish(func(Confirmation) {})
+
+	logMu.Lock()
+	defer logMu.Unlock()
+	for _, line := range logs {
+		if strings.Contains(line, "could not put channel in confirm mode") {
+			return
+		}
+	}
+	t.Fatalf("expected a confirm mode error to be logged, got logs: %q", logs)
+}

--- a/publish.go
+++ b/publish.go
@@ -115,8 +115,11 @@ func NewPublisher(conn *Conn, optionFuncs ...func(*PublisherOptions)) (*Publishe
 	go publisher.startNotifyBlockedHandler()
 
 	if options.ConfirmMode {
+		if err := publisher.chanManager.ConfirmSafe(false); err != nil {
+			return nil, fmt.Errorf("could not put channel in confirm mode: %w", err)
+		}
 		publisher.NotifyPublish(func(_ Confirmation) {
-			// set a blank handler to set the channel in confirm mode
+			// set a blank handler to start the confirmation listener
 		})
 	}
 
@@ -374,7 +377,14 @@ func (publisher *Publisher) startPublishHandler() {
 		return
 	}
 	publisher.handlerMu.Unlock()
-	publisher.chanManager.ConfirmSafe(false)
+
+	if err := publisher.chanManager.ConfirmSafe(false); err != nil {
+		// the channel manager will reconnect and start this handler again
+		publisher.options.Logger.Errorf(
+			"could not put channel in confirm mode, confirmations disabled until next reconnect: %v", err,
+		)
+		return
+	}
 
 	go func() {
 		confirmationCh := publisher.chanManager.NotifyPublishSafe(make(chan amqp.Confirmation, 1))


### PR DESCRIPTION
- The error from putting the channel in confirm mode was silently discarded in `startPublishHandler`, leaving `NotifyPublish` handlers that never fire (and skipping the confirm-mode restore on reconnect, since the flag is only set on success).
- `NewPublisher` with `WithPublisherOptionsConfirm` now fails construction if confirm mode can't be established.
- `startPublishHandler` now logs the error and skips starting the confirmation listener; the next reconnect retries it.
- Adds an integration test asserting the error is logged when confirm mode can't be established.