### PR TITLE
Don't log empty string for unparseable AMQP URLs

### DIFF
--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -53,7 +53,10 @@ func dial(log logger.Logger, resolver Resolver, conf amqp.Config) (*amqp.Connect
 }
 
 func maskPassword(urlToMask string) string {
-	parsedUrl, _ := url.Parse(urlToMask)
+	parsedUrl, err := url.Parse(urlToMask)
+	if err != nil {
+		return "<unparseable url redacted>"
+	}
 	return parsedUrl.Redacted()
 }
 

--- a/internal/connectionmanager/connection_manager_test.go
+++ b/internal/connectionmanager/connection_manager_test.go
@@ -1,6 +1,9 @@
 package connectionmanager
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func Test_maskUrl(t *testing.T) {
 	tests := []struct {
@@ -36,5 +39,15 @@ func Test_maskUrl(t *testing.T) {
 				t.Errorf("masked password = %v, but wanted %v", maskPassword(tt.url), tt.expected)
 			}
 		})
+	}
+}
+
+func Test_maskPasswordUnparseableURL(t *testing.T) {
+	masked := maskPassword("amqp://user:pass@localhost:5672/%zz")
+	if masked == "" {
+		t.Error("masked url is empty")
+	}
+	if strings.Contains(masked, "pass") {
+		t.Errorf("masked url %q leaks the password", masked)
 	}
 }


### PR DESCRIPTION
- `maskPassword` discarded the `url.Parse` error; an unparseable URL made `Redacted()` return an empty string, so dial-failure warnings logged nothing where the server URL belongs.
- Falls back to a redacted placeholder on parse failure.