### PR TITLE
Convert nested Tables so amqp accepts them

### DIFF
--- a/table.go
+++ b/table.go
@@ -1,28 +1,26 @@
 package rabbitmq
 
 import (
-	"maps"
-
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 // Table stores user supplied fields of the following types:
 //
-//   bool
-//   byte
-//   float32
-//   float64
-//   int
-//   int16
-//   int32
-//   int64
-//   nil
-//   string
-//   time.Time
-//   amqp.Decimal
-//   amqp.Table
-//   []byte
-//   []interface{} - containing above types
+//	bool
+//	byte
+//	float32
+//	float64
+//	int
+//	int16
+//	int32
+//	int64
+//	nil
+//	string
+//	time.Time
+//	amqp.Decimal
+//	amqp.Table
+//	[]byte
+//	[]interface{} - containing above types
 //
 // Functions taking a table will immediately fail when the table contains a
 // value of an unsupported type.
@@ -33,11 +31,29 @@ import (
 // Use a type assertion when reading values from a table for type conversion.
 //
 // RabbitMQ expects int32 for integer values.
-//
 type Table map[string]interface{}
 
 func tableToAMQPTable(table Table) amqp.Table {
 	amqpTable := make(amqp.Table, len(table))
-	maps.Copy(amqpTable, table)
+	for k, v := range table {
+		amqpTable[k] = tableValue(v)
+	}
 	return amqpTable
+}
+
+// tableValue converts nested Tables to amqp.Tables, which is required for
+// the amqp library to accept them as field values
+func tableValue(v interface{}) interface{} {
+	switch typed := v.(type) {
+	case Table:
+		return tableToAMQPTable(typed)
+	case []interface{}:
+		converted := make([]interface{}, len(typed))
+		for i, item := range typed {
+			converted[i] = tableValue(item)
+		}
+		return converted
+	default:
+		return v
+	}
 }

--- a/table_test.go
+++ b/table_test.go
@@ -1,0 +1,21 @@
+package rabbitmq
+
+import "testing"
+
+func TestTableToAMQPTableNested(t *testing.T) {
+	table := Table{
+		"top": "level",
+		"nested": Table{
+			"x-match": "all",
+		},
+		"list": []interface{}{
+			Table{"deep": int32(1)},
+			"plain",
+		},
+	}
+
+	converted := tableToAMQPTable(table)
+	if err := converted.Validate(); err != nil {
+		t.Fatalf("converted table failed amqp validation: %v", err)
+	}
+}


### PR DESCRIPTION
- `tableToAMQPTable` only converted the top level, so a `Table` nested inside headers or args (e.g. for headers exchanges) failed amqp091 validation with `table field value rabbitmq.Table not supported`, despite the `Table` docs advertising nested table support.
- Conversion is now recursive, including `Table`s inside `[]interface{}` values.