### PR TITLE
Merge consumer exchange args instead of replacing

### DIFF
--- a/consumer_options.go
+++ b/consumer_options.go
@@ -220,11 +220,17 @@ func WithConsumerOptionsExchangePassive(options *ConsumerOptions) {
 	options.ExchangeOptions[0].Passive = true
 }
 
-// WithConsumerOptionsExchangeArgs adds optional args to the exchange
+// WithConsumerOptionsExchangeArgs adds optional args to the exchange,
+// merging onto any args already set
 func WithConsumerOptionsExchangeArgs(args Table) func(*ConsumerOptions) {
 	return func(options *ConsumerOptions) {
 		ensureExchangeOptions(options)
-		options.ExchangeOptions[0].Args = args
+		if options.ExchangeOptions[0].Args == nil {
+			options.ExchangeOptions[0].Args = Table{}
+		}
+		for k, v := range args {
+			options.ExchangeOptions[0].Args[k] = v
+		}
 	}
 }
 

--- a/consumer_options_test.go
+++ b/consumer_options_test.go
@@ -79,3 +79,17 @@ func TestWithPublisherOptionsExchangeArgs_LaterValueWins(t *testing.T) {
 		t.Errorf("alternate-exchange = %v, want %q", got, "second")
 	}
 }
+
+func TestWithConsumerOptionsExchangeArgs_MergesWithExisting(t *testing.T) {
+	opts := &ConsumerOptions{}
+
+	WithConsumerOptionsExchangeArgs(Table{"alternate-exchange": "keep"})(opts)
+	WithConsumerOptionsExchangeArgs(Table{"x-new": "added"})(opts)
+
+	if got := opts.ExchangeOptions[0].Args["alternate-exchange"]; got != "keep" {
+		t.Errorf("alternate-exchange dropped: got %v", got)
+	}
+	if got := opts.ExchangeOptions[0].Args["x-new"]; got != "added" {
+		t.Errorf("x-new = %v, want %v", got, "added")
+	}
+}


### PR DESCRIPTION
- `WithConsumerOptionsExchangeArgs` replaced the whole args map, silently dropping args set by earlier options — the same option-order bug class fixed for queue and publisher exchange args in #206/#218.
- Now merges like its siblings.