### PR TITLE
Dispatch reconnect notifications without blocking

### DIFF
--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -1,17 +1,14 @@
 package dispatcher
 
 import (
-	"log"
-	"math"
-	"math/rand/v2"
 	"sync"
-	"time"
 )
 
-// Dispatcher -
+// Dispatcher fans out reconnect notifications to subscribers
 type Dispatcher struct {
-	subscribers   map[int]dispatchSubscriber
-	subscribersMu *sync.Mutex
+	subscribers      map[uint64]dispatchSubscriber
+	subscribersMu    *sync.Mutex
+	nextSubscriberID uint64
 }
 
 type dispatchSubscriber struct {
@@ -22,20 +19,27 @@ type dispatchSubscriber struct {
 // NewDispatcher -
 func NewDispatcher() *Dispatcher {
 	return &Dispatcher{
-		subscribers:   make(map[int]dispatchSubscriber),
+		subscribers:   make(map[uint64]dispatchSubscriber),
 		subscribersMu: &sync.Mutex{},
 	}
 }
 
-// Dispatch -
+// Dispatch sends the error to all subscribers without blocking.
+// A subscriber that hasn't consumed its previous notification only keeps
+// the latest one; restart logic re-reads current state, so intermediate
+// notifications are safe to coalesce.
 func (d *Dispatcher) Dispatch(err error) error {
 	d.subscribersMu.Lock()
 	defer d.subscribersMu.Unlock()
 	for _, subscriber := range d.subscribers {
 		select {
-		case <-time.After(time.Second * 5):
-			log.Println("Unexpected rabbitmq error: timeout in dispatch")
 		case subscriber.notifyCancelOrCloseChan <- err:
+		default:
+			select {
+			case <-subscriber.notifyCancelOrCloseChan:
+			default:
+			}
+			subscriber.notifyCancelOrCloseChan <- err
 		}
 	}
 	return nil
@@ -43,19 +47,19 @@ func (d *Dispatcher) Dispatch(err error) error {
 
 // AddSubscriber -
 func (d *Dispatcher) AddSubscriber() (<-chan error, chan<- struct{}) {
-	id := rand.IntN(math.MaxInt)
-
 	closeCh := make(chan struct{})
-	notifyCancelOrCloseChan := make(chan error)
+	notifyCancelOrCloseChan := make(chan error, 1)
 
 	d.subscribersMu.Lock()
+	id := d.nextSubscriberID
+	d.nextSubscriberID++
 	d.subscribers[id] = dispatchSubscriber{
 		notifyCancelOrCloseChan: notifyCancelOrCloseChan,
 		closeCh:                 closeCh,
 	}
 	d.subscribersMu.Unlock()
 
-	go func(id int) {
+	go func(id uint64) {
 		<-closeCh
 		d.subscribersMu.Lock()
 		defer d.subscribersMu.Unlock()

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -1,6 +1,7 @@
 package dispatcher
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -37,5 +38,33 @@ func TestCloseSubscriber(t *testing.T) {
 	defer d.subscribersMu.Unlock()
 	if len(d.subscribers) != 0 {
 		t.Error("Dispatcher subscribers length is not 0")
+	}
+}
+
+func TestDispatchDoesNotBlockOnSlowSubscriber(t *testing.T) {
+	d := NewDispatcher()
+	notifyCh, _ := d.AddSubscriber()
+
+	done := make(chan struct{})
+	go func() {
+		d.Dispatch(errors.New("first"))
+		d.Dispatch(errors.New("second"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch blocked on a slow subscriber")
+	}
+
+	// a slow subscriber keeps the latest notification
+	select {
+	case err := <-notifyCh:
+		if err.Error() != "second" {
+			t.Fatalf("got %q, want latest notification %q", err, "second")
+		}
+	default:
+		t.Fatal("expected a buffered notification")
 	}
 }


### PR DESCRIPTION
- `Dispatch` held the subscriber mutex while blocking up to 5s per slow subscriber, stalling every other subscriber and `AddSubscriber`; on timeout the notification was silently dropped via a stdlib `log` call that bypassed the configured logger.
- Subscriber channels are now buffered (cap 1) with keep-latest semantics — the same pattern as the blocked-notification fan-out — so dispatch never blocks and a slow subscriber always sees the most recent reconnect. Coalescing is safe because restart logic re-reads current channel state.
- Subscriber IDs are now a monotonic counter instead of a random int, removing the (theoretical) collision that would orphan a subscriber.