### PR TITLE
Stop reconnecting after Close

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -42,10 +43,12 @@ func waitForHealthyAmqp(t *testing.T, connStr string, optionFuncs ...func(*Conne
 	defer cancel()
 	tkr := time.NewTicker(time.Second)
 
-	// only log connection-level logs when connection has succeeded
-	muted := true
+	// only log connection-level logs when connection has succeeded;
+	// atomic because connection goroutines log concurrently with the test
+	var muted atomic.Bool
+	muted.Store(true)
 	connLogger := simpleLogF(func(s string, i ...interface{}) {
-		if !muted {
+		if !muted.Load() {
 			t.Logf(s, i...)
 		}
 	})
@@ -77,7 +80,7 @@ func waitForHealthyAmqp(t *testing.T, connStr string, optionFuncs ...func(*Conne
 					t.Log("publish ping failed", err.Error())
 				} else {
 					t.Log("ping successful")
-					muted = true
+					muted.Store(true)
 					return conn
 				}
 			}
@@ -329,4 +332,56 @@ func TestNotifyPublishSurfacesConfirmError(t *testing.T) {
 		}
 	}
 	t.Fatalf("expected a confirm mode error to be logged, got logs: %q", logs)
+}
+
+// TestConnCloseDuringReconnectStaysClosed closes a connection while its
+// reconnect loop is dialing a dead broker, then brings the broker back:
+// the closed connection must never reconnect.
+func TestConnCloseDuringReconnectStaysClosed(t *testing.T) {
+	if v, ok := os.LookupEnv(enableDockerIntegrationTestsFlag); !ok || strings.ToUpper(v) != "TRUE" {
+		t.Skipf("integration tests are only run if '%s' is TRUE", enableDockerIntegrationTestsFlag)
+	}
+	const hostPort = "5673"
+	connStr := fmt.Sprintf("amqp://guest:guest@localhost:%s/", hostPort)
+
+	runBroker := func() string {
+		out, err := exec.Command("docker", "run", "--rm", "--detach", "--publish="+hostPort+":5672", "--quiet", "--", "rabbitmq:4.1.1-alpine").Output()
+		if err != nil {
+			t.Fatalf("error launching rabbitmq in docker: %v", err)
+		}
+		id := strings.TrimSpace(string(out))
+		t.Cleanup(func() {
+			_ = exec.Command("docker", "rm", "--force", id).Run()
+		})
+		return id
+	}
+
+	brokerID := runBroker()
+	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsReconnectInterval(100*time.Millisecond))
+
+	if err := exec.Command("docker", "rm", "--force", brokerID).Run(); err != nil {
+		t.Fatal("failed to kill broker", err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for !conn.IsClosed() {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for connection to notice dead broker")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// the reconnect loop is now dialing a dead broker
+	_ = conn.Close()
+
+	runBroker()
+	healthy := waitForHealthyAmqp(t, connStr, WithConnectionOptionsReconnectInterval(100*time.Millisecond))
+	defer healthy.Close()
+
+	// give the closed connection's reconnect loop time to (wrongly) reconnect
+	for range 20 {
+		if !conn.IsClosed() {
+			t.Fatal("closed connection reconnected to the restarted broker")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -22,7 +22,12 @@ type ChannelManager struct {
 	reconnectionCountMu *sync.Mutex
 	dispatcher          *dispatcher.Dispatcher
 	confirmMode         bool
+	done                chan struct{}
 }
+
+// errManagerClosed signals the reconnect loop that the manager was
+// deliberately closed and reconnecting should stop
+var errManagerClosed = errors.New("channel manager is closed")
 
 // NewChannelManager creates a new connection manager
 func NewChannelManager(connManager *connectionmanager.ConnectionManager, log logger.Logger, reconnectInterval time.Duration) (*ChannelManager, error) {
@@ -40,6 +45,7 @@ func NewChannelManager(connManager *connectionmanager.ConnectionManager, log log
 		reconnectionCount:   0,
 		reconnectionCountMu: &sync.Mutex{},
 		dispatcher:          dispatcher.NewDispatcher(),
+		done:                make(chan struct{}),
 	}
 	go chanManager.startNotifyCancelOrClosed()
 	return &chanManager, nil
@@ -100,8 +106,15 @@ func (chanManager *ChannelManager) incrementReconnectionCount() {
 func (chanManager *ChannelManager) reconnectLoop() {
 	for {
 		chanManager.logger.Infof("waiting %s seconds to attempt to reconnect to amqp server", chanManager.reconnectInterval)
-		time.Sleep(chanManager.reconnectInterval)
+		select {
+		case <-chanManager.done:
+			return
+		case <-time.After(chanManager.reconnectInterval):
+		}
 		err := chanManager.reconnect()
+		if errors.Is(err, errManagerClosed) {
+			return
+		}
 		if err != nil {
 			chanManager.logger.Errorf("error reconnecting to amqp server: %v", err)
 		} else {
@@ -116,6 +129,13 @@ func (chanManager *ChannelManager) reconnectLoop() {
 func (chanManager *ChannelManager) reconnect() error {
 	chanManager.channelMu.Lock()
 	defer chanManager.channelMu.Unlock()
+
+	select {
+	case <-chanManager.done:
+		return errManagerClosed
+	default:
+	}
+
 	newChannel, err := getNewChannel(chanManager.connManager)
 	if err != nil {
 		return err
@@ -140,12 +160,13 @@ func (chanManager *ChannelManager) Close() error {
 	chanManager.channelMu.Lock()
 	defer chanManager.channelMu.Unlock()
 
-	err := chanManager.channel.Close()
-	if err != nil {
-		return err
+	select {
+	case <-chanManager.done:
+	default:
+		close(chanManager.done)
 	}
 
-	return nil
+	return chanManager.channel.Close()
 }
 
 // NotifyReconnect adds a new subscriber that will receive error messages whenever

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -26,7 +26,12 @@ type ConnectionManager struct {
 	blockedSubscribers      map[uint64]chan amqp.Blocking
 	blockedSubscribersMu    *sync.Mutex
 	nextBlockedSubscriberID uint64
+	done                    chan struct{}
 }
+
+// errManagerClosed signals the reconnect loop that the manager was
+// deliberately closed and reconnecting should stop
+var errManagerClosed = errors.New("connection manager is closed")
 
 type Resolver interface {
 	Resolve() ([]string, error)
@@ -79,6 +84,7 @@ func NewConnectionManager(resolver Resolver, conf amqp.Config, log logger.Logger
 		dispatcher:           dispatcher.NewDispatcher(),
 		blockedSubscribers:   make(map[uint64]chan amqp.Blocking),
 		blockedSubscribersMu: &sync.Mutex{},
+		done:                 make(chan struct{}),
 	}
 	go connManager.startNotifyClose()
 	connManager.startNotifyBlocked(conn)
@@ -91,11 +97,13 @@ func (connManager *ConnectionManager) Close() error {
 	connManager.connectionMu.Lock()
 	defer connManager.connectionMu.Unlock()
 
-	err := connManager.connection.Close()
-	if err != nil {
-		return err
+	select {
+	case <-connManager.done:
+	default:
+		close(connManager.done)
 	}
-	return nil
+
+	return connManager.connection.Close()
 }
 
 // NotifyReconnect adds a new subscriber that will receive error messages whenever
@@ -151,8 +159,15 @@ func (connManager *ConnectionManager) incrementReconnectionCount() {
 func (connManager *ConnectionManager) reconnectLoop() {
 	for {
 		connManager.logger.Infof("waiting %s seconds to attempt to reconnect to amqp server", connManager.ReconnectInterval)
-		time.Sleep(connManager.ReconnectInterval)
+		select {
+		case <-connManager.done:
+			return
+		case <-time.After(connManager.ReconnectInterval):
+		}
 		err := connManager.reconnect()
+		if errors.Is(err, errManagerClosed) {
+			return
+		}
 		if err != nil {
 			connManager.logger.Errorf("error reconnecting to amqp server: %v", err)
 		} else {
@@ -167,6 +182,12 @@ func (connManager *ConnectionManager) reconnectLoop() {
 func (connManager *ConnectionManager) reconnect() error {
 	connManager.connectionMu.Lock()
 	defer connManager.connectionMu.Unlock()
+
+	select {
+	case <-connManager.done:
+		return errManagerClosed
+	default:
+	}
 
 	conn, err := dial(connManager.logger, connManager.resolver, amqp.Config(connManager.amqpConfig))
 	if err != nil {


### PR DESCRIPTION
- The reconnect loops had no shutdown signal: calling `Close()` while the broker was down left the loop dialing, and once the broker returned it opened a brand-new connection (or channel) that nothing would ever close.
- Both managers now carry a `done` channel closed by `Close()`; the reconnect loop exits on it, and `reconnect()` re-checks it under the lock so a close that races the dial still wins.
- Adds an integration test that kills the broker, closes the connection mid-reconnect-loop, restarts the broker, and asserts the connection stays closed (it reconnected within ~7s before the fix).
- Also fixes a latent data race in the `waitForHealthyAmqp` test helper's `muted` flag that the new test surfaced under `-race`.