### PR TITLE
Exponential backoff with jitter on reconnect

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -59,7 +59,7 @@ func NewClusterConn(resolver Resolver, opts ...func(*ConnectionOptions)) (*Conn,
 		optFn(options)
 	}
 
-	manager, err := connectionmanager.NewConnectionManager(resolver, amqp.Config(options.Config), options.Logger, options.ReconnectInterval)
+	manager, err := connectionmanager.NewConnectionManager(resolver, amqp.Config(options.Config), options.Logger, options.BaseReconnectInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/connection_options.go
+++ b/connection_options.go
@@ -4,24 +4,26 @@ import "time"
 
 // ConnectionOptions are used to describe how a new consumer will be created.
 type ConnectionOptions struct {
-	ReconnectInterval time.Duration
-	Logger            Logger
-	Config            Config
+	BaseReconnectInterval time.Duration
+	Logger                Logger
+	Config                Config
 }
 
 // getDefaultConnectionOptions describes the options that will be used when a value isn't provided
 func getDefaultConnectionOptions() ConnectionOptions {
 	return ConnectionOptions{
-		ReconnectInterval: time.Second * 5,
-		Logger:            stdDebugLogger{},
-		Config:            Config{},
+		BaseReconnectInterval: time.Second * 5,
+		Logger:                stdDebugLogger{},
+		Config:                Config{},
 	}
 }
 
-// WithConnectionOptionsReconnectInterval sets the reconnection interval
-func WithConnectionOptionsReconnectInterval(interval time.Duration) func(options *ConnectionOptions) {
+// WithConnectionOptionsBaseReconnectInterval sets the base reconnection interval.
+// Consecutive failed attempts back off exponentially from this value, capped
+// at 16x, with up to 25% jitter.
+func WithConnectionOptionsBaseReconnectInterval(interval time.Duration) func(options *ConnectionOptions) {
 	return func(options *ConnectionOptions) {
-		options.ReconnectInterval = interval
+		options.BaseReconnectInterval = interval
 	}
 }
 

--- a/consume.go
+++ b/consume.go
@@ -62,7 +62,7 @@ func NewConsumer(
 		return nil, errors.New("connection manager can't be nil")
 	}
 
-	chanManager, err := channelmanager.NewChannelManager(conn.connectionManager, options.Logger, conn.connectionManager.ReconnectInterval)
+	chanManager, err := channelmanager.NewChannelManager(conn.connectionManager, options.Logger, conn.connectionManager.BaseReconnectInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -191,7 +191,7 @@ func TestPublisherCloseReleasesBlockedHandler(t *testing.T) {
 
 func TestPublisherRestoresConfirmModeBeforeReconnectCompletes(t *testing.T) {
 	connStr := prepareDockerTest(t)
-	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsReconnectInterval(10*time.Millisecond))
+	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsBaseReconnectInterval(10*time.Millisecond))
 	defer conn.Close()
 
 	tests := []struct {
@@ -357,7 +357,7 @@ func TestConnCloseDuringReconnectStaysClosed(t *testing.T) {
 	}
 
 	brokerID := runBroker()
-	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsReconnectInterval(100*time.Millisecond))
+	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsBaseReconnectInterval(100*time.Millisecond))
 
 	if err := exec.Command("docker", "rm", "--force", brokerID).Run(); err != nil {
 		t.Fatal("failed to kill broker", err)
@@ -374,7 +374,7 @@ func TestConnCloseDuringReconnectStaysClosed(t *testing.T) {
 	_ = conn.Close()
 
 	runBroker()
-	healthy := waitForHealthyAmqp(t, connStr, WithConnectionOptionsReconnectInterval(100*time.Millisecond))
+	healthy := waitForHealthyAmqp(t, connStr, WithConnectionOptionsBaseReconnectInterval(100*time.Millisecond))
 	defer healthy.Close()
 
 	// give the closed connection's reconnect loop time to (wrongly) reconnect

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -1,0 +1,19 @@
+package backoff
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// Delay returns how long to wait before reconnect attempt number attempt
+// (0-indexed): the base interval doubled per attempt, capped at 16x base,
+// with up to 25% subtracted as jitter so a fleet of clients doesn't
+// reconnect in lockstep after a broker restart.
+func Delay(base time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	delay := base << min(attempt, 4)
+	jitter := time.Duration(rand.Int64N(int64(delay)/4 + 1))
+	return delay - jitter
+}

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -1,0 +1,40 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDelayGrowsAndCaps(t *testing.T) {
+	const base = time.Second
+
+	tests := []struct {
+		attempt int
+		max     time.Duration
+	}{
+		{attempt: 0, max: base},
+		{attempt: 1, max: 2 * base},
+		{attempt: 2, max: 4 * base},
+		{attempt: 3, max: 8 * base},
+		{attempt: 4, max: 16 * base},
+		{attempt: 5, max: 16 * base},
+		{attempt: 100, max: 16 * base},
+	}
+
+	for _, tt := range tests {
+		// jitter is random, so sample repeatedly
+		for range 100 {
+			got := Delay(base, tt.attempt)
+			lower := tt.max * 3 / 4
+			if got < lower || got > tt.max {
+				t.Fatalf("Delay(base, %d) = %s, want within (%s, %s]", tt.attempt, got, lower, tt.max)
+			}
+		}
+	}
+}
+
+func TestDelayZeroBase(t *testing.T) {
+	if got := Delay(0, 3); got != 0 {
+		t.Fatalf("Delay(0, 3) = %s, want 0", got)
+	}
+}

--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/wagslane/go-rabbitmq/internal/backoff"
 	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
 	"github.com/wagslane/go-rabbitmq/internal/dispatcher"
 	"github.com/wagslane/go-rabbitmq/internal/logger"
@@ -13,16 +14,16 @@ import (
 
 // ChannelManager -
 type ChannelManager struct {
-	logger              logger.Logger
-	channel             *amqp.Channel
-	connManager         *connectionmanager.ConnectionManager
-	channelMu           *sync.RWMutex
-	reconnectInterval   time.Duration
-	reconnectionCount   uint
-	reconnectionCountMu *sync.Mutex
-	dispatcher          *dispatcher.Dispatcher
-	confirmMode         bool
-	done                chan struct{}
+	logger                logger.Logger
+	channel               *amqp.Channel
+	connManager           *connectionmanager.ConnectionManager
+	channelMu             *sync.RWMutex
+	baseReconnectInterval time.Duration
+	reconnectionCount     uint
+	reconnectionCountMu   *sync.Mutex
+	dispatcher            *dispatcher.Dispatcher
+	confirmMode           bool
+	done                  chan struct{}
 }
 
 // errManagerClosed signals the reconnect loop that the manager was
@@ -30,22 +31,22 @@ type ChannelManager struct {
 var errManagerClosed = errors.New("channel manager is closed")
 
 // NewChannelManager creates a new connection manager
-func NewChannelManager(connManager *connectionmanager.ConnectionManager, log logger.Logger, reconnectInterval time.Duration) (*ChannelManager, error) {
+func NewChannelManager(connManager *connectionmanager.ConnectionManager, log logger.Logger, baseReconnectInterval time.Duration) (*ChannelManager, error) {
 	ch, err := getNewChannel(connManager)
 	if err != nil {
 		return nil, err
 	}
 
 	chanManager := ChannelManager{
-		logger:              log,
-		connManager:         connManager,
-		channel:             ch,
-		channelMu:           &sync.RWMutex{},
-		reconnectInterval:   reconnectInterval,
-		reconnectionCount:   0,
-		reconnectionCountMu: &sync.Mutex{},
-		dispatcher:          dispatcher.NewDispatcher(),
-		done:                make(chan struct{}),
+		logger:                log,
+		connManager:           connManager,
+		channel:               ch,
+		channelMu:             &sync.RWMutex{},
+		baseReconnectInterval: baseReconnectInterval,
+		reconnectionCount:     0,
+		reconnectionCountMu:   &sync.Mutex{},
+		dispatcher:            dispatcher.NewDispatcher(),
+		done:                  make(chan struct{}),
 	}
 	go chanManager.startNotifyCancelOrClosed()
 	return &chanManager, nil
@@ -104,12 +105,13 @@ func (chanManager *ChannelManager) incrementReconnectionCount() {
 
 // reconnectLoop continuously attempts to reconnect
 func (chanManager *ChannelManager) reconnectLoop() {
-	for {
-		chanManager.logger.Infof("waiting %s seconds to attempt to reconnect to amqp server", chanManager.reconnectInterval)
+	for attempt := 0; ; attempt++ {
+		delay := backoff.Delay(chanManager.baseReconnectInterval, attempt)
+		chanManager.logger.Infof("waiting %s to attempt to reconnect to amqp server", delay)
 		select {
 		case <-chanManager.done:
 			return
-		case <-time.After(chanManager.reconnectInterval):
+		case <-time.After(delay):
 		}
 		err := chanManager.reconnect()
 		if errors.Is(err, errManagerClosed) {

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/wagslane/go-rabbitmq/internal/backoff"
 	"github.com/wagslane/go-rabbitmq/internal/dispatcher"
 	"github.com/wagslane/go-rabbitmq/internal/logger"
 )
@@ -19,7 +20,7 @@ type ConnectionManager struct {
 	connection              *amqp.Connection
 	amqpConfig              amqp.Config
 	connectionMu            *sync.RWMutex
-	ReconnectInterval       time.Duration
+	BaseReconnectInterval   time.Duration
 	reconnectionCount       uint
 	reconnectionCountMu     *sync.Mutex
 	dispatcher              *dispatcher.Dispatcher
@@ -63,25 +64,25 @@ func maskPassword(urlToMask string) string {
 }
 
 // NewConnectionManager creates a new connection manager
-func NewConnectionManager(resolver Resolver, conf amqp.Config, log logger.Logger, reconnectInterval time.Duration) (*ConnectionManager, error) {
+func NewConnectionManager(resolver Resolver, conf amqp.Config, log logger.Logger, baseReconnectInterval time.Duration) (*ConnectionManager, error) {
 	conn, err := dial(log, resolver, amqp.Config(conf))
 	if err != nil {
 		return nil, err
 	}
 
 	connManager := ConnectionManager{
-		logger:               log,
-		resolver:             resolver,
-		connection:           conn,
-		amqpConfig:           conf,
-		connectionMu:         &sync.RWMutex{},
-		ReconnectInterval:    reconnectInterval,
-		reconnectionCount:    0,
-		reconnectionCountMu:  &sync.Mutex{},
-		dispatcher:           dispatcher.NewDispatcher(),
-		blockedSubscribers:   make(map[uint64]chan amqp.Blocking),
-		blockedSubscribersMu: &sync.Mutex{},
-		done:                 make(chan struct{}),
+		logger:                log,
+		resolver:              resolver,
+		connection:            conn,
+		amqpConfig:            conf,
+		connectionMu:          &sync.RWMutex{},
+		BaseReconnectInterval: baseReconnectInterval,
+		reconnectionCount:     0,
+		reconnectionCountMu:   &sync.Mutex{},
+		dispatcher:            dispatcher.NewDispatcher(),
+		blockedSubscribers:    make(map[uint64]chan amqp.Blocking),
+		blockedSubscribersMu:  &sync.Mutex{},
+		done:                  make(chan struct{}),
 	}
 	go connManager.startNotifyClose()
 	connManager.startNotifyBlocked(conn)
@@ -154,12 +155,13 @@ func (connManager *ConnectionManager) incrementReconnectionCount() {
 
 // reconnectLoop continuously attempts to reconnect
 func (connManager *ConnectionManager) reconnectLoop() {
-	for {
-		connManager.logger.Infof("waiting %s seconds to attempt to reconnect to amqp server", connManager.ReconnectInterval)
+	for attempt := 0; ; attempt++ {
+		delay := backoff.Delay(connManager.BaseReconnectInterval, attempt)
+		connManager.logger.Infof("waiting %s to attempt to reconnect to amqp server", delay)
 		select {
 		case <-connManager.done:
 			return
-		case <-time.After(connManager.ReconnectInterval):
+		case <-time.After(delay):
 		}
 		err := connManager.reconnect()
 		if errors.Is(err, errManagerClosed) {

--- a/publish.go
+++ b/publish.go
@@ -83,7 +83,7 @@ func NewPublisher(conn *Conn, optionFuncs ...func(*PublisherOptions)) (*Publishe
 		return nil, errors.New("connection manager can't be nil")
 	}
 
-	chanManager, err := channelmanager.NewChannelManager(conn.connectionManager, options.Logger, conn.connectionManager.ReconnectInterval)
+	chanManager, err := channelmanager.NewChannelManager(conn.connectionManager, options.Logger, conn.connectionManager.BaseReconnectInterval)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Reconnects retried at a fixed interval forever, so a fleet of clients hammers a recovering broker in lockstep after a restart.
- Delays now double per failed attempt from the configured base interval, capped at 16x, with up to 25% jitter (`internal/backoff`, unit-tested). Each disconnect starts fresh at the base.
- Renames `ReconnectInterval` to `BaseReconnectInterval` and `WithConnectionOptionsReconnectInterval` to `WithConnectionOptionsBaseReconnectInterval` since it's no longer the literal interval.
- Also fixes the "waiting 5s seconds" log wording since the line changed anyway.

Stacked on #232 (touches the same reconnect loops) — merge that first and this retargets to main.