### PR TITLE
Don't hold flow/blocked state locks across publish I/O

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/wagslane/go-rabbitmq/internal/channelmanager"
@@ -47,16 +48,14 @@ type Publisher struct {
 	reconnectErrCh             <-chan error
 	closeConnectionToManagerCh chan<- struct{}
 
-	disablePublishDueToFlow   bool
-	disablePublishDueToFlowMu *sync.RWMutex
+	disablePublishDueToFlow    atomic.Bool
+	disablePublishDueToBlocked atomic.Bool
 
-	disablePublishDueToBlocked   bool
-	disablePublishDueToBlockedMu *sync.RWMutex
-	blockedNotifications         <-chan amqp.Blocking
-	unsubscribeBlocked           func()
-	done                         chan struct{}
-	blockedHandlerDone           chan struct{}
-	closeOnce                    *sync.Once
+	blockedNotifications <-chan amqp.Blocking
+	unsubscribeBlocked   func()
+	done                 chan struct{}
+	blockedHandlerDone   chan struct{}
+	closeOnce            *sync.Once
 
 	handlerMu            *sync.Mutex
 	notifyReturnHandler  func(r Return)
@@ -90,21 +89,17 @@ func NewPublisher(conn *Conn, optionFuncs ...func(*PublisherOptions)) (*Publishe
 
 	reconnectErrCh, closeCh := chanManager.NotifyReconnect()
 	publisher := &Publisher{
-		chanManager:                  chanManager,
-		connManager:                  conn.connectionManager,
-		reconnectErrCh:               reconnectErrCh,
-		closeConnectionToManagerCh:   closeCh,
-		disablePublishDueToFlow:      false,
-		disablePublishDueToFlowMu:    &sync.RWMutex{},
-		disablePublishDueToBlocked:   false,
-		disablePublishDueToBlockedMu: &sync.RWMutex{},
-		done:                         make(chan struct{}),
-		blockedHandlerDone:           make(chan struct{}),
-		closeOnce:                    &sync.Once{},
-		handlerMu:                    &sync.Mutex{},
-		notifyReturnHandler:          nil,
-		notifyPublishHandler:         nil,
-		options:                      *options,
+		chanManager:                chanManager,
+		connManager:                conn.connectionManager,
+		reconnectErrCh:             reconnectErrCh,
+		closeConnectionToManagerCh: closeCh,
+		done:                       make(chan struct{}),
+		blockedHandlerDone:         make(chan struct{}),
+		closeOnce:                  &sync.Once{},
+		handlerMu:                  &sync.Mutex{},
+		notifyReturnHandler:        nil,
+		notifyPublishHandler:       nil,
+		options:                    *options,
 	}
 
 	err = publisher.startup()
@@ -177,15 +172,10 @@ func (publisher *Publisher) PublishWithContext(
 	routingKeys []string,
 	optionFuncs ...func(*PublishOptions),
 ) error {
-	publisher.disablePublishDueToFlowMu.RLock()
-	defer publisher.disablePublishDueToFlowMu.RUnlock()
-	if publisher.disablePublishDueToFlow {
+	if publisher.disablePublishDueToFlow.Load() {
 		return fmt.Errorf("publishing blocked due to high flow on the server")
 	}
-
-	publisher.disablePublishDueToBlockedMu.RLock()
-	defer publisher.disablePublishDueToBlockedMu.RUnlock()
-	if publisher.disablePublishDueToBlocked {
+	if publisher.disablePublishDueToBlocked.Load() {
 		return fmt.Errorf("publishing blocked due to TCP block on the server")
 	}
 
@@ -243,15 +233,10 @@ func (publisher *Publisher) PublishWithDeferredConfirmWithContext(
 	routingKeys []string,
 	optionFuncs ...func(*PublishOptions),
 ) (PublisherConfirmation, error) {
-	publisher.disablePublishDueToFlowMu.RLock()
-	defer publisher.disablePublishDueToFlowMu.RUnlock()
-	if publisher.disablePublishDueToFlow {
+	if publisher.disablePublishDueToFlow.Load() {
 		return nil, fmt.Errorf("publishing blocked due to high flow on the server")
 	}
-
-	publisher.disablePublishDueToBlockedMu.RLock()
-	defer publisher.disablePublishDueToBlockedMu.RUnlock()
-	if publisher.disablePublishDueToBlocked {
+	if publisher.disablePublishDueToBlocked.Load() {
 		return nil, fmt.Errorf("publishing blocked due to TCP block on the server")
 	}
 

--- a/publish_flow_block.go
+++ b/publish_flow_block.go
@@ -2,44 +2,34 @@ package rabbitmq
 
 func (publisher *Publisher) startNotifyFlowHandler() {
 	notifyFlowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
-	publisher.disablePublishDueToFlowMu.Lock()
-	publisher.disablePublishDueToFlow = false
-	publisher.disablePublishDueToFlowMu.Unlock()
+	publisher.disablePublishDueToFlow.Store(false)
 
 	for ok := range notifyFlowChan {
-		publisher.disablePublishDueToFlowMu.Lock()
 		if ok {
 			publisher.options.Logger.Warnf("pausing publishing due to flow request from server")
-			publisher.disablePublishDueToFlow = true
 		} else {
-			publisher.disablePublishDueToFlow = false
 			publisher.options.Logger.Warnf("resuming publishing due to flow request from server")
 		}
-		publisher.disablePublishDueToFlowMu.Unlock()
+		publisher.disablePublishDueToFlow.Store(ok)
 	}
 }
 
 func (publisher *Publisher) startNotifyBlockedHandler() {
 	defer close(publisher.blockedHandlerDone)
 
-	publisher.disablePublishDueToBlockedMu.Lock()
-	publisher.disablePublishDueToBlocked = false
-	publisher.disablePublishDueToBlockedMu.Unlock()
+	publisher.disablePublishDueToBlocked.Store(false)
 
 	for {
 		select {
 		case <-publisher.done:
 			return
 		case b := <-publisher.blockedNotifications:
-			publisher.disablePublishDueToBlockedMu.Lock()
 			if b.Active {
 				publisher.options.Logger.Warnf("pausing publishing due to TCP blocking from server")
-				publisher.disablePublishDueToBlocked = true
 			} else {
-				publisher.disablePublishDueToBlocked = false
 				publisher.options.Logger.Warnf("resuming publishing due to TCP blocking from server")
 			}
-			publisher.disablePublishDueToBlockedMu.Unlock()
+			publisher.disablePublishDueToBlocked.Store(b.Active)
 		}
 	}
 }

--- a/publish_test.go
+++ b/publish_test.go
@@ -30,3 +30,18 @@ func TestPublisherRestartContinuesAfterError(t *testing.T) {
 		t.Fatalf("restart attempts = %d, want 2", restarts)
 	}
 }
+
+func TestPublishFailsFastWhenPaused(t *testing.T) {
+	publisher := &Publisher{}
+
+	publisher.disablePublishDueToFlow.Store(true)
+	if err := publisher.Publish([]byte{}, []string{"key"}); err == nil {
+		t.Fatal("expected an error while paused due to flow")
+	}
+	publisher.disablePublishDueToFlow.Store(false)
+
+	publisher.disablePublishDueToBlocked.Store(true)
+	if err := publisher.Publish([]byte{}, []string{"key"}); err == nil {
+		t.Fatal("expected an error while paused due to TCP block")
+	}
+}


### PR DESCRIPTION
- Publishes held read locks on the flow/blocked state mutexes for the entire publish, including network I/O and reconnect waits. A flow or blocked event arriving mid-publish queued a writer, and Go's RWMutex writer-preference then blocked every new publish behind it — including publishes with already-cancelled contexts (reproduced: a cancelled-context publish hung indefinitely behind one pending state writer).
- The two pause flags are now `atomic.Bool`s: publishes check them without blocking, and the flow/blocked handlers update them without waiting for in-flight publishes.
- Adds a unit test covering the fail-fast gate for both pause states.