### PR TITLE
Fix wrong and truncated doc comments

### DIFF
--- a/connection_options.go
+++ b/connection_options.go
@@ -25,14 +25,13 @@ func WithConnectionOptionsReconnectInterval(interval time.Duration) func(options
 	}
 }
 
-// WithConnectionOptionsLogging sets logging to true on the consumer options
-// and sets the
+// WithConnectionOptionsLogging uses a default logger that writes to std out
 func WithConnectionOptionsLogging(options *ConnectionOptions) {
 	options.Logger = stdDebugLogger{}
 }
 
-// WithConnectionOptionsLogger sets logging to true on the consumer options
-// and sets the
+// WithConnectionOptionsLogger sets logging to a custom interface.
+// Use WithConnectionOptionsLogging to just log to stdout.
 func WithConnectionOptionsLogger(log Logger) func(options *ConnectionOptions) {
 	return func(options *ConnectionOptions) {
 		options.Logger = log

--- a/consume.go
+++ b/consume.go
@@ -83,6 +83,9 @@ func NewConsumer(
 
 // Run starts consuming with automatic reconnection handling. Do not reuse the
 // consumer for anything other than to close it.
+// Run blocks until the consumer is closed. Recovery errors after the initial
+// startup (including permanent ones like mismatched queue args) are logged
+// and retried on the next reconnect rather than returned.
 func (consumer *Consumer) Run(handler Handler) error {
 	handlerWrapper := func(d Delivery) (action Action) {
 		if !consumer.handlerMu.TryRLock() {

--- a/consumer_options.go
+++ b/consumer_options.go
@@ -61,9 +61,8 @@ func getDefaultBindingOptions() BindingOptions {
 }
 
 // ConsumerOptions are used to describe how a new consumer will be created.
-// If QueueOptions is not nil, the options will be used to declare a queue
-// If ExchangeOptions is not nil, it will be used to declare an exchange
-// If there are Bindings, the queue will be bound to them
+// QueueOptions is used to declare the queue, ExchangeOptions to declare
+// exchanges, and each exchange's Bindings to bind the queue to it.
 type ConsumerOptions struct {
 	RabbitConsumerOptions RabbitConsumerOptions
 	QueueOptions          QueueOptions
@@ -100,7 +99,7 @@ type QueueOptions struct {
 	Declare    bool
 }
 
-// Binding describes the bhinding of a queue to a routing key on an exchange
+// Binding describes the binding of a queue to a routing key on an exchange
 type Binding struct {
 	RoutingKey string
 	BindingOptions
@@ -139,7 +138,7 @@ func WithConsumerOptionsQueuePassive(options *ConsumerOptions) {
 }
 
 // WithConsumerOptionsQueueNoDeclare will turn off the declaration of the queue's
-// existance upon startup
+// existence upon startup
 func WithConsumerOptionsQueueNoDeclare(options *ConsumerOptions) {
 	options.QueueOptions.Declare = false
 }
@@ -176,7 +175,7 @@ func WithConsumerOptionsExchangeName(name string) func(*ConsumerOptions) {
 	}
 }
 
-// WithConsumerOptionsExchangeKind ensures the queue is a durable queue
+// WithConsumerOptionsExchangeKind sets the exchange kind, i.e. direct, topic, fanout, or headers
 func WithConsumerOptionsExchangeKind(kind string) func(*ConsumerOptions) {
 	return func(options *ConsumerOptions) {
 		ensureExchangeOptions(options)
@@ -208,7 +207,7 @@ func WithConsumerOptionsExchangeNoWait(options *ConsumerOptions) {
 	options.ExchangeOptions[0].NoWait = true
 }
 
-// WithConsumerOptionsExchangeDeclare stops this library from declaring the exchanges existance
+// WithConsumerOptionsExchangeDeclare makes this library declare the exchange on startup
 func WithConsumerOptionsExchangeDeclare(options *ConsumerOptions) {
 	ensureExchangeOptions(options)
 	options.ExchangeOptions[0].Declare = true

--- a/publish.go
+++ b/publish.go
@@ -336,7 +336,9 @@ func (publisher *Publisher) NotifyReturn(handler func(r Return)) {
 	}
 }
 
-// NotifyPublish registers a listener for publish confirmations, must set ConfirmPublishings option
+// NotifyPublish registers a listener for publish confirmations.
+// Registering a handler implicitly puts the channel in confirm mode
+// (WithPublisherOptionsConfirm does the same at construction).
 // These notifications are shared across an entire connection, so if you're creating multiple
 // publishers on the same connection keep that in mind.
 // The handler is called sequentially in delivery-tag order; a blocking handler delays subsequent confirmations.

--- a/publisher_options.go
+++ b/publisher_options.go
@@ -29,8 +29,7 @@ func getDefaultPublisherOptions() PublisherOptions {
 	}
 }
 
-// WithPublisherOptionsLogging sets logging to true on the publisher options
-// and sets the
+// WithPublisherOptionsLogging uses a default logger that writes to std out
 func WithPublisherOptionsLogging(options *PublisherOptions) {
 	options.Logger = &stdDebugLogger{}
 }
@@ -50,7 +49,7 @@ func WithPublisherOptionsExchangeName(name string) func(*PublisherOptions) {
 	}
 }
 
-// WithPublisherOptionsExchangeKind ensures the queue is a durable queue
+// WithPublisherOptionsExchangeKind sets the exchange kind, i.e. direct, topic, fanout, or headers
 func WithPublisherOptionsExchangeKind(kind string) func(*PublisherOptions) {
 	return func(options *PublisherOptions) {
 		options.ExchangeOptions.Kind = kind


### PR DESCRIPTION
- `WithConsumerOptionsExchangeDeclare` said it *stops* declaring the exchange while it does the opposite; both `ExchangeKind` options claimed to "ensure the queue is a durable queue".
- Fixes truncated "and sets the" sentences on the logging options, the stale `ConfirmPublishings` option name in `NotifyPublish` docs, and typos (bhinding, existance).
- Documents `Consumer.Run`'s contract: it blocks until Close and retries recovery errors instead of returning them.