### PR TITLE
Make close methods idempotent

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"math/rand/v2"
 	"slices"
+	"sync"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 
@@ -16,7 +17,9 @@ type Conn struct {
 	reconnectErrCh             <-chan error
 	closeConnectionToManagerCh chan<- struct{}
 
-	options ConnectionOptions
+	options   ConnectionOptions
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // Config wraps amqp.Config
@@ -84,8 +87,11 @@ func (conn *Conn) handleRestarts() {
 // You should also close any consumers and publishers before
 // closing the connection
 func (conn *Conn) Close() error {
-	conn.closeConnectionToManagerCh <- struct{}{}
-	return conn.connectionManager.Close()
+	conn.closeOnce.Do(func() {
+		conn.closeConnectionToManagerCh <- struct{}{}
+		conn.closeErr = conn.connectionManager.Close()
+	})
+	return conn.closeErr
 }
 
 // IsClosed returns whether the connection is closed or not

--- a/consume.go
+++ b/consume.go
@@ -34,6 +34,7 @@ type Consumer struct {
 	closeConnectionToManagerCh chan<- struct{}
 	options                    ConsumerOptions
 	handlerMu                  *sync.RWMutex
+	closeOnce                  sync.Once
 
 	isClosedMu *sync.RWMutex
 	isClosed   bool
@@ -135,18 +136,18 @@ func (consumer *Consumer) restartOnReconnect(restart func() error) {
 // Use CloseWithContext to specify a context to cancel the handler completion.
 // It does not close the connection manager, just the subscription
 // to the connection manager and the consuming goroutines.
-// Only call once.
 func (consumer *Consumer) Close() {
-	if consumer.options.CloseGracefully {
-		consumer.options.Logger.Infof("waiting for handler to finish...")
-		err := consumer.waitForHandlerCompletion(context.Background())
-		if err != nil {
-			consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)
+	consumer.closeOnce.Do(func() {
+		if consumer.options.CloseGracefully {
+			consumer.options.Logger.Infof("waiting for handler to finish...")
+			err := consumer.waitForHandlerCompletion(context.Background())
+			if err != nil {
+				consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)
+			}
 		}
-	}
 
-	consumer.cleanupResources()
-
+		consumer.cleanupResources()
+	})
 }
 
 func (consumer *Consumer) cleanupResources() {
@@ -172,16 +173,17 @@ func (consumer *Consumer) cleanupResources() {
 // Use the context to cancel the handler completion.
 // CloseWithContext does not close the connection manager, just the subscription
 // to the connection manager and the consuming goroutines.
-// Only call once.
 func (consumer *Consumer) CloseWithContext(ctx context.Context) {
-	if consumer.options.CloseGracefully {
-		err := consumer.waitForHandlerCompletion(ctx)
-		if err != nil {
-			consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)
+	consumer.closeOnce.Do(func() {
+		if consumer.options.CloseGracefully {
+			err := consumer.waitForHandlerCompletion(ctx)
+			if err != nil {
+				consumer.options.Logger.Warnf("error while waiting for handler to finish: %v", err)
+			}
 		}
-	}
 
-	consumer.cleanupResources()
+		consumer.cleanupResources()
+	})
 }
 
 // startGoroutines declares the queue if it doesn't exist,

--- a/integration_test.go
+++ b/integration_test.go
@@ -189,6 +189,26 @@ func TestPublisherCloseReleasesBlockedHandler(t *testing.T) {
 	}
 }
 
+func TestCloseIsIdempotent(t *testing.T) {
+	connStr := prepareDockerTest(t)
+	conn := waitForHealthyAmqp(t, connStr)
+
+	consumer, err := NewConsumer(conn, "close_is_idempotent")
+	if err != nil {
+		t.Fatal("error creating consumer", err)
+	}
+	consumer.Close()
+	consumer.Close()
+	consumer.CloseWithContext(context.Background())
+
+	if err := conn.Close(); err != nil {
+		t.Fatal("error closing connection", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal("second connection close returned an error", err)
+	}
+}
+
 func TestPublisherRestoresConfirmModeBeforeReconnectCompletes(t *testing.T) {
 	connStr := prepareDockerTest(t)
 	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsBaseReconnectInterval(10*time.Millisecond))


### PR DESCRIPTION
- Make connection and consumer shutdown safe to call repeatedly
- Preserve the first connection close result
- Cover repeated and mixed consumer close calls with integration tests