### PR TITLE
Use zero-value mutex fields

### DIFF
--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -17,10 +17,10 @@ type ChannelManager struct {
 	logger                logger.Logger
 	channel               *amqp.Channel
 	connManager           *connectionmanager.ConnectionManager
-	channelMu             *sync.RWMutex
+	channelMu             sync.RWMutex
 	baseReconnectInterval time.Duration
 	reconnectionCount     uint
-	reconnectionCountMu   *sync.Mutex
+	reconnectionCountMu   sync.Mutex
 	dispatcher            *dispatcher.Dispatcher
 	confirmMode           bool
 	done                  chan struct{}
@@ -41,10 +41,8 @@ func NewChannelManager(connManager *connectionmanager.ConnectionManager, log log
 		logger:                log,
 		connManager:           connManager,
 		channel:               ch,
-		channelMu:             &sync.RWMutex{},
 		baseReconnectInterval: baseReconnectInterval,
 		reconnectionCount:     0,
-		reconnectionCountMu:   &sync.Mutex{},
 		dispatcher:            dispatcher.NewDispatcher(),
 		done:                  make(chan struct{}),
 	}

--- a/internal/channelmanager/safe_wraps_test.go
+++ b/internal/channelmanager/safe_wraps_test.go
@@ -3,7 +3,6 @@ package channelmanager
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestLockChannelReadHonorsContext(t *testing.T) {
-	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	manager := &ChannelManager{}
 	manager.channelMu.Lock()
 	defer manager.channelMu.Unlock()
 
@@ -29,7 +28,7 @@ func TestLockChannelReadHonorsContext(t *testing.T) {
 }
 
 func TestPublishWithContextSafeHonorsContextWhileChannelLocked(t *testing.T) {
-	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	manager := &ChannelManager{}
 	manager.channelMu.Lock()
 	defer manager.channelMu.Unlock()
 
@@ -43,7 +42,7 @@ func TestPublishWithContextSafeHonorsContextWhileChannelLocked(t *testing.T) {
 }
 
 func TestPublishWithDeferredConfirmContextSafeHonorsContextWhileChannelLocked(t *testing.T) {
-	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	manager := &ChannelManager{}
 	manager.channelMu.Lock()
 	defer manager.channelMu.Unlock()
 
@@ -62,7 +61,7 @@ func TestPublishWithDeferredConfirmContextSafeHonorsContextWhileChannelLocked(t 
 }
 
 func TestLockChannelReadRejectsCanceledContext(t *testing.T) {
-	manager := &ChannelManager{channelMu: &sync.RWMutex{}}
+	manager := &ChannelManager{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 

--- a/internal/connectionmanager/blocked_test.go
+++ b/internal/connectionmanager/blocked_test.go
@@ -1,7 +1,6 @@
 package connectionmanager
 
 import (
-	"sync"
 	"testing"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -9,8 +8,7 @@ import (
 
 func newBlockedTestManager() *ConnectionManager {
 	return &ConnectionManager{
-		blockedSubscribers:   make(map[uint64]chan amqp.Blocking),
-		blockedSubscribersMu: &sync.Mutex{},
+		blockedSubscribers: make(map[uint64]chan amqp.Blocking),
 	}
 }
 

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -19,13 +19,13 @@ type ConnectionManager struct {
 	resolver                Resolver
 	connection              *amqp.Connection
 	amqpConfig              amqp.Config
-	connectionMu            *sync.RWMutex
+	connectionMu            sync.RWMutex
 	BaseReconnectInterval   time.Duration
 	reconnectionCount       uint
-	reconnectionCountMu     *sync.Mutex
+	reconnectionCountMu     sync.Mutex
 	dispatcher              *dispatcher.Dispatcher
 	blockedSubscribers      map[uint64]chan amqp.Blocking
-	blockedSubscribersMu    *sync.Mutex
+	blockedSubscribersMu    sync.Mutex
 	nextBlockedSubscriberID uint64
 	done                    chan struct{}
 }
@@ -78,13 +78,10 @@ func NewConnectionManager(resolver Resolver, conf amqp.Config, log logger.Logger
 		resolver:              resolver,
 		connection:            conn,
 		amqpConfig:            conf,
-		connectionMu:          &sync.RWMutex{},
 		BaseReconnectInterval: baseReconnectInterval,
 		reconnectionCount:     0,
-		reconnectionCountMu:   &sync.Mutex{},
 		dispatcher:            dispatcher.NewDispatcher(),
 		blockedSubscribers:    make(map[uint64]chan amqp.Blocking),
-		blockedSubscribersMu:  &sync.Mutex{},
 		done:                  make(chan struct{}),
 	}
 	go connManager.startNotifyClose()

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -7,7 +7,7 @@ import (
 // Dispatcher fans out reconnect notifications to subscribers
 type Dispatcher struct {
 	subscribers      map[uint64]dispatchSubscriber
-	subscribersMu    *sync.Mutex
+	subscribersMu    sync.Mutex
 	nextSubscriberID uint64
 }
 
@@ -19,8 +19,7 @@ type dispatchSubscriber struct {
 // NewDispatcher -
 func NewDispatcher() *Dispatcher {
 	return &Dispatcher{
-		subscribers:   make(map[uint64]dispatchSubscriber),
-		subscribersMu: &sync.Mutex{},
+		subscribers: make(map[uint64]dispatchSubscriber),
 	}
 }
 

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -11,9 +11,6 @@ func TestNewDispatcher(t *testing.T) {
 	if d.subscribers == nil {
 		t.Error("Dispatcher subscribers is nil")
 	}
-	if d.subscribersMu == nil {
-		t.Error("Dispatcher subscribersMu is nil")
-	}
 }
 
 func TestAddSubscriber(t *testing.T) {


### PR DESCRIPTION
- Store internal mutexes directly instead of allocating pointers
- Remove redundant constructor initialization
- Simplify tests to rely on the standard library mutex zero value