### PR TITLE
Make CI reproducible and test main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -24,7 +26,7 @@ jobs:
 
       - name: install staticcheck
         run: |
-          cd /tmp && go install honnef.co/go/tools/cmd/staticcheck@latest
+          cd /tmp && go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 
       - name: Make tests
         run: |


### PR DESCRIPTION
- Run the existing test workflow on pushes to main
- Pin Staticcheck to v0.7.0 instead of floating on latest