### PR TITLE
fix: Stop Reconnect Loops After Close to Prevent Channel Exhaustion

### DIFF
--- a/flow_block_test.go
+++ b/flow_block_test.go
@@ -1,0 +1,130 @@
+package rabbitmq
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// newFlowBlockTestPublisher builds a Publisher with only the fields needed to
+// exercise the flow/blocked notification handlers, so the resume logic can be
+// tested without a real broker (runs in default CI).
+func newFlowBlockTestPublisher() *Publisher {
+	return &Publisher{
+		disablePublishDueToFlowMu:    &sync.RWMutex{},
+		disablePublishDueToBlockedMu: &sync.RWMutex{},
+		options:                      getDefaultPublisherOptions(),
+		done:                         make(chan struct{}),
+	}
+}
+
+func (publisher *Publisher) isBlocked() bool {
+	publisher.disablePublishDueToBlockedMu.RLock()
+	defer publisher.disablePublishDueToBlockedMu.RUnlock()
+	return publisher.disablePublishDueToBlocked
+}
+
+func (publisher *Publisher) isFlowDisabled() bool {
+	publisher.disablePublishDueToFlowMu.RLock()
+	defer publisher.disablePublishDueToFlowMu.RUnlock()
+	return publisher.disablePublishDueToFlow
+}
+
+func eventually(t *testing.T, want bool, get func() bool, msg string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tkr := time.NewTicker(5 * time.Millisecond)
+	defer tkr.Stop()
+	for {
+		if get() == want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("%s: timed out waiting for state to become %v", msg, want)
+		case <-tkr.C:
+		}
+	}
+}
+
+// TestPublisherResumesOnUnblock is the ENG-1846 regression test: after a
+// connection.blocked pauses publishing, a connection.unblocked must clear the
+// paused state so publishing resumes — without a reconnect.
+func TestPublisherResumesOnUnblock(t *testing.T) {
+	publisher := newFlowBlockTestPublisher()
+	blockings := make(chan amqp.Blocking, 1)
+
+	resubscribe := make(chan bool, 1)
+	go func() { resubscribe <- publisher.consumeBlockings(blockings) }()
+
+	if publisher.isBlocked() {
+		t.Fatal("publisher should start unblocked")
+	}
+
+	// Broker blocks: publishing pauses.
+	blockings <- amqp.Blocking{Active: true, Reason: "low on memory"}
+	eventually(t, true, publisher.isBlocked, "after connection.blocked")
+
+	// Broker unblocks: publishing must resume.
+	blockings <- amqp.Blocking{Active: false}
+	eventually(t, false, publisher.isBlocked, "after connection.unblocked")
+
+	// Connection drop closes the receiver: the handler asks to re-subscribe.
+	close(blockings)
+	select {
+	case got := <-resubscribe:
+		if !got {
+			t.Fatal("expected consumeBlockings to request re-subscribe when receiver closes")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeBlockings did not return after receiver closed")
+	}
+}
+
+// TestPublisherConsumeBlockingsStopsOnClose verifies the handler exits (does not
+// re-subscribe) when the publisher itself is closed.
+func TestPublisherConsumeBlockingsStopsOnClose(t *testing.T) {
+	publisher := newFlowBlockTestPublisher()
+	blockings := make(chan amqp.Blocking)
+
+	resubscribe := make(chan bool, 1)
+	go func() { resubscribe <- publisher.consumeBlockings(blockings) }()
+
+	close(publisher.done)
+	select {
+	case got := <-resubscribe:
+		if got {
+			t.Fatal("expected consumeBlockings to stop (not re-subscribe) on publisher close")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeBlockings did not return after publisher close")
+	}
+}
+
+// TestPublisherResumesOnFlow mirrors the unblock test for channel-level flow
+// control (basic.flow).
+func TestPublisherResumesOnFlow(t *testing.T) {
+	publisher := newFlowBlockTestPublisher()
+	flow := make(chan bool, 1)
+
+	resubscribe := make(chan bool, 1)
+	go func() { resubscribe <- publisher.consumeFlow(flow) }()
+
+	flow <- true
+	eventually(t, true, publisher.isFlowDisabled, "after basic.flow active")
+
+	flow <- false
+	eventually(t, false, publisher.isFlowDisabled, "after basic.flow inactive")
+
+	close(flow)
+	select {
+	case got := <-resubscribe:
+		if !got {
+			t.Fatal("expected consumeFlow to request re-subscribe when receiver closes")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumeFlow did not return after receiver closed")
+	}
+}

--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -115,13 +115,16 @@ func (chanManager *ChannelManager) reconnectLoop() {
 func (chanManager *ChannelManager) reconnect() error {
 	chanManager.channelMu.Lock()
 	defer chanManager.channelMu.Unlock()
+
+	if chanManager.channel != nil {
+		if err := chanManager.channel.Close(); err != nil {
+			chanManager.logger.Warnf("error closing channel while reconnecting: %v", err)
+		}
+	}
+
 	newChannel, err := getNewChannel(chanManager.connManager)
 	if err != nil {
 		return err
-	}
-
-	if err = chanManager.channel.Close(); err != nil {
-		chanManager.logger.Warnf("error closing channel while reconnecting: %v", err)
 	}
 
 	chanManager.channel = newChannel

--- a/internal/connectionmanager/connection_manager.go
+++ b/internal/connectionmanager/connection_manager.go
@@ -159,13 +159,15 @@ func (connManager *ConnectionManager) reconnect() error {
 	connManager.connectionMu.Lock()
 	defer connManager.connectionMu.Unlock()
 
+	if connManager.connection != nil {
+		if err := connManager.connection.Close(); err != nil {
+			connManager.logger.Warnf("error closing connection while reconnecting: %v", err)
+		}
+	}
+
 	conn, err := dial(connManager.logger, connManager.resolver, amqp.Config(connManager.amqpConfig))
 	if err != nil {
 		return err
-	}
-
-	if err = connManager.connection.Close(); err != nil {
-		connManager.logger.Warnf("error closing connection while reconnecting: %v", err)
 	}
 
 	connManager.connection = conn

--- a/publish.go
+++ b/publish.go
@@ -108,6 +108,15 @@ func NewPublisher(conn *Conn, optionFuncs ...func(*PublisherOptions)) (*Publishe
 		return nil, err
 	}
 
+	// Start the flow/blocked notification handlers exactly once for the lifetime
+	// of the publisher. They self-heal across reconnections by re-subscribing on
+	// the new channel/connection, so they must NOT be (re)started from startup()
+	// (which runs again on every reconnection) or they would leak a goroutine and
+	// a registered notification channel per reconnect — eventually wedging the
+	// amqp connection reader and preventing resume on unblock (ENG-1846).
+	go publisher.startNotifyFlowHandler()
+	go publisher.startNotifyBlockedHandler()
+
 	if options.ConfirmMode {
 		publisher.NotifyPublish(func(_ Confirmation) {
 			// set a blank handler to set the channel in confirm mode
@@ -136,8 +145,6 @@ func (publisher *Publisher) startup() error {
 	if err != nil {
 		return fmt.Errorf("declare exchange failed: %w", err)
 	}
-	go publisher.startNotifyFlowHandler()
-	go publisher.startNotifyBlockedHandler()
 	return nil
 }
 

--- a/publish_flow_block.go
+++ b/publish_flow_block.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (publisher *Publisher) startNotifyFlowHandler() {
-	flowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
+	notifyFlowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
 	publisher.disablePublishDueToFlowMu.Lock()
 	publisher.disablePublishDueToFlow = false
 	publisher.disablePublishDueToFlowMu.Unlock()
@@ -14,7 +14,7 @@ func (publisher *Publisher) startNotifyFlowHandler() {
 		select {
 		case <-publisher.done:
 			return
-		case ok, open := <-flowChan:
+		case ok, open := <-notifyFlowChan:
 			if !open {
 				return
 			}

--- a/publish_flow_block.go
+++ b/publish_flow_block.go
@@ -5,80 +5,82 @@ import (
 )
 
 func (publisher *Publisher) startNotifyFlowHandler() {
-	for {
-		select {
-		case <-publisher.done:
-			return
-		default:
-		}
-		if publisher.connManager.IsClosed() {
-			return
-		}
-
-		notifyFlowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
+	for publisher.notifyHandlerReady() {
+		flowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
 		publisher.disablePublishDueToFlowMu.Lock()
 		publisher.disablePublishDueToFlow = false
 		publisher.disablePublishDueToFlowMu.Unlock()
 
-	flowLoop:
-		for {
-			select {
-			case <-publisher.done:
-				return
-			case ok, open := <-notifyFlowChan:
-				if !open {
-					break flowLoop
-				}
-				publisher.disablePublishDueToFlowMu.Lock()
-				if ok {
-					publisher.options.Logger.Warnf("pausing publishing due to flow request from server")
-					publisher.disablePublishDueToFlow = true
-				} else {
-					publisher.disablePublishDueToFlow = false
-					publisher.options.Logger.Warnf("resuming publishing due to flow request from server")
-				}
-				publisher.disablePublishDueToFlowMu.Unlock()
+		if !publisher.handleFlowEvents(flowChan) {
+			return
+		}
+	}
+}
+
+func (publisher *Publisher) handleFlowEvents(flowChan <-chan bool) bool {
+	for {
+		select {
+		case <-publisher.done:
+			return false
+		case ok, open := <-flowChan:
+			if !open {
+				return true // channel closed, re-register
 			}
+			publisher.disablePublishDueToFlowMu.Lock()
+			if ok {
+				publisher.options.Logger.Warnf("pausing publishing due to flow request from server")
+				publisher.disablePublishDueToFlow = true
+			} else {
+				publisher.disablePublishDueToFlow = false
+				publisher.options.Logger.Warnf("resuming publishing due to flow request from server")
+			}
+			publisher.disablePublishDueToFlowMu.Unlock()
 		}
 	}
 }
 
 func (publisher *Publisher) startNotifyBlockedHandler() {
-	for {
-		// Check if closed before (re-)registering
-		select {
-		case <-publisher.done:
-			return
-		default:
-		}
-		if publisher.connManager.IsClosed() {
-			return
-		}
-
+	for publisher.notifyHandlerReady() {
 		blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking))
 		publisher.disablePublishDueToBlockedMu.Lock()
 		publisher.disablePublishDueToBlocked = false
 		publisher.disablePublishDueToBlockedMu.Unlock()
 
-	blockedLoop:
-		for {
-			select {
-			case <-publisher.done:
-				return
-			case b, open := <-blockings:
-				if !open {
-					break blockedLoop
-				}
-				publisher.disablePublishDueToBlockedMu.Lock()
-				if b.Active {
-					publisher.options.Logger.Warnf("pausing publishing due to TCP blocking from server")
-					publisher.disablePublishDueToBlocked = true
-				} else {
-					publisher.disablePublishDueToBlocked = false
-					publisher.options.Logger.Warnf("resuming publishing due to TCP blocking from server")
-				}
-				publisher.disablePublishDueToBlockedMu.Unlock()
-			}
+		if !publisher.handleBlockedEvents(blockings) {
+			return
 		}
 	}
+}
+
+func (publisher *Publisher) handleBlockedEvents(blockings <-chan amqp.Blocking) bool {
+	for {
+		select {
+		case <-publisher.done:
+			return false
+		case b, open := <-blockings:
+			if !open {
+				return true // channel closed, re-register
+			}
+			publisher.disablePublishDueToBlockedMu.Lock()
+			if b.Active {
+				publisher.options.Logger.Warnf("pausing publishing due to TCP blocking from server")
+				publisher.disablePublishDueToBlocked = true
+			} else {
+				publisher.disablePublishDueToBlocked = false
+				publisher.options.Logger.Warnf("resuming publishing due to TCP blocking from server")
+			}
+			publisher.disablePublishDueToBlockedMu.Unlock()
+		}
+	}
+}
+
+// notifyHandlerReady checks if the handler should proceed to register.
+// Returns false if publisher is closing or connection is closed.
+func (publisher *Publisher) notifyHandlerReady() bool {
+	select {
+	case <-publisher.done:
+		return false
+	default:
+	}
+	return !publisher.connManager.IsClosed()
 }

--- a/publish_flow_block.go
+++ b/publish_flow_block.go
@@ -5,39 +5,80 @@ import (
 )
 
 func (publisher *Publisher) startNotifyFlowHandler() {
-	notifyFlowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
-	publisher.disablePublishDueToFlowMu.Lock()
-	publisher.disablePublishDueToFlow = false
-	publisher.disablePublishDueToFlowMu.Unlock()
-
-	for ok := range notifyFlowChan {
-		publisher.disablePublishDueToFlowMu.Lock()
-		if ok {
-			publisher.options.Logger.Warnf("pausing publishing due to flow request from server")
-			publisher.disablePublishDueToFlow = true
-		} else {
-			publisher.disablePublishDueToFlow = false
-			publisher.options.Logger.Warnf("resuming publishing due to flow request from server")
+	for {
+		select {
+		case <-publisher.done:
+			return
+		default:
 		}
+		if publisher.connManager.IsClosed() {
+			return
+		}
+
+		notifyFlowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
+		publisher.disablePublishDueToFlowMu.Lock()
+		publisher.disablePublishDueToFlow = false
 		publisher.disablePublishDueToFlowMu.Unlock()
+
+	flowLoop:
+		for {
+			select {
+			case <-publisher.done:
+				return
+			case ok, open := <-notifyFlowChan:
+				if !open {
+					break flowLoop
+				}
+				publisher.disablePublishDueToFlowMu.Lock()
+				if ok {
+					publisher.options.Logger.Warnf("pausing publishing due to flow request from server")
+					publisher.disablePublishDueToFlow = true
+				} else {
+					publisher.disablePublishDueToFlow = false
+					publisher.options.Logger.Warnf("resuming publishing due to flow request from server")
+				}
+				publisher.disablePublishDueToFlowMu.Unlock()
+			}
+		}
 	}
 }
 
 func (publisher *Publisher) startNotifyBlockedHandler() {
-	blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking))
-	publisher.disablePublishDueToBlockedMu.Lock()
-	publisher.disablePublishDueToBlocked = false
-	publisher.disablePublishDueToBlockedMu.Unlock()
-
-	for b := range blockings {
-		publisher.disablePublishDueToBlockedMu.Lock()
-		if b.Active {
-			publisher.options.Logger.Warnf("pausing publishing due to TCP blocking from server")
-			publisher.disablePublishDueToBlocked = true
-		} else {
-			publisher.disablePublishDueToBlocked = false
-			publisher.options.Logger.Warnf("resuming publishing due to TCP blocking from server")
+	for {
+		// Check if closed before (re-)registering
+		select {
+		case <-publisher.done:
+			return
+		default:
 		}
+		if publisher.connManager.IsClosed() {
+			return
+		}
+
+		blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking))
+		publisher.disablePublishDueToBlockedMu.Lock()
+		publisher.disablePublishDueToBlocked = false
 		publisher.disablePublishDueToBlockedMu.Unlock()
+
+	blockedLoop:
+		for {
+			select {
+			case <-publisher.done:
+				return
+			case b, open := <-blockings:
+				if !open {
+					break blockedLoop
+				}
+				publisher.disablePublishDueToBlockedMu.Lock()
+				if b.Active {
+					publisher.options.Logger.Warnf("pausing publishing due to TCP blocking from server")
+					publisher.disablePublishDueToBlocked = true
+				} else {
+					publisher.disablePublishDueToBlocked = false
+					publisher.options.Logger.Warnf("resuming publishing due to TCP blocking from server")
+				}
+				publisher.disablePublishDueToBlockedMu.Unlock()
+			}
+		}
 	}
 }

--- a/publish_flow_block.go
+++ b/publish_flow_block.go
@@ -5,26 +5,18 @@ import (
 )
 
 func (publisher *Publisher) startNotifyFlowHandler() {
-	for publisher.notifyHandlerReady() {
-		flowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
-		publisher.disablePublishDueToFlowMu.Lock()
-		publisher.disablePublishDueToFlow = false
-		publisher.disablePublishDueToFlowMu.Unlock()
+	flowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
+	publisher.disablePublishDueToFlowMu.Lock()
+	publisher.disablePublishDueToFlow = false
+	publisher.disablePublishDueToFlowMu.Unlock()
 
-		if !publisher.handleFlowEvents(flowChan) {
-			return
-		}
-	}
-}
-
-func (publisher *Publisher) handleFlowEvents(flowChan <-chan bool) bool {
 	for {
 		select {
 		case <-publisher.done:
-			return false
+			return
 		case ok, open := <-flowChan:
 			if !open {
-				return true // channel closed, re-register
+				return
 			}
 			publisher.disablePublishDueToFlowMu.Lock()
 			if ok {
@@ -40,26 +32,18 @@ func (publisher *Publisher) handleFlowEvents(flowChan <-chan bool) bool {
 }
 
 func (publisher *Publisher) startNotifyBlockedHandler() {
-	for publisher.notifyHandlerReady() {
-		blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking))
-		publisher.disablePublishDueToBlockedMu.Lock()
-		publisher.disablePublishDueToBlocked = false
-		publisher.disablePublishDueToBlockedMu.Unlock()
+	blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking))
+	publisher.disablePublishDueToBlockedMu.Lock()
+	publisher.disablePublishDueToBlocked = false
+	publisher.disablePublishDueToBlockedMu.Unlock()
 
-		if !publisher.handleBlockedEvents(blockings) {
-			return
-		}
-	}
-}
-
-func (publisher *Publisher) handleBlockedEvents(blockings <-chan amqp.Blocking) bool {
 	for {
 		select {
 		case <-publisher.done:
-			return false
+			return
 		case b, open := <-blockings:
 			if !open {
-				return true // channel closed, re-register
+				return
 			}
 			publisher.disablePublishDueToBlockedMu.Lock()
 			if b.Active {
@@ -72,15 +56,4 @@ func (publisher *Publisher) handleBlockedEvents(blockings <-chan amqp.Blocking) 
 			publisher.disablePublishDueToBlockedMu.Unlock()
 		}
 	}
-}
-
-// notifyHandlerReady checks if the handler should proceed to register.
-// Returns false if publisher is closing or connection is closed.
-func (publisher *Publisher) notifyHandlerReady() bool {
-	select {
-	case <-publisher.done:
-		return false
-	default:
-	}
-	return !publisher.connManager.IsClosed()
 }

--- a/publish_flow_block.go
+++ b/publish_flow_block.go
@@ -1,59 +1,150 @@
 package rabbitmq
 
 import (
+	"time"
+
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-func (publisher *Publisher) startNotifyFlowHandler() {
-	notifyFlowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool))
-	publisher.disablePublishDueToFlowMu.Lock()
-	publisher.disablePublishDueToFlow = false
-	publisher.disablePublishDueToFlowMu.Unlock()
+// minResubscribeWait is the minimum pause between re-subscription attempts when the
+// underlying notification channel closes (i.e. the channel/connection dropped).
+// It avoids a tight spin while the connection manager is reconnecting.
+const minResubscribeWait = 500 * time.Millisecond
 
+// startNotifyFlowHandler keeps a subscription to channel-level flow control
+// (basic.flow) alive for the whole lifetime of the publisher. When the
+// underlying amqp channel is recreated on reconnect its flow channel is closed,
+// so we re-subscribe on the new channel rather than letting the handler die.
+func (publisher *Publisher) startNotifyFlowHandler() {
 	for {
 		select {
 		case <-publisher.done:
 			return
-		case ok, open := <-notifyFlowChan:
-			if !open {
-				return
-			}
-			publisher.disablePublishDueToFlowMu.Lock()
-			if ok {
-				publisher.options.Logger.Warnf("pausing publishing due to flow request from server")
-				publisher.disablePublishDueToFlow = true
-			} else {
-				publisher.disablePublishDueToFlow = false
-				publisher.options.Logger.Warnf("resuming publishing due to flow request from server")
-			}
-			publisher.disablePublishDueToFlowMu.Unlock()
+		default:
+		}
+
+		// NotifyFlowSafe blocks until any in-progress channel reconnect releases
+		// the channel lock, so we always register against the live channel. The
+		// receiver is buffered so the amqp reader goroutine is never blocked
+		// delivering a flow event to us.
+		notifyFlowChan := publisher.chanManager.NotifyFlowSafe(make(chan bool, 1))
+		publisher.setFlow(false)
+
+		if !publisher.consumeFlow(notifyFlowChan) {
+			return // publisher closed
+		}
+
+		// Channel closed (reconnect in progress). Pause before re-subscribing.
+		if !publisher.waitBeforeResubscribe() {
+			return
 		}
 	}
 }
 
+// startNotifyBlockedHandler keeps a subscription to connection-level TCP flow
+// control (connection.blocked / connection.unblocked) alive for the whole
+// lifetime of the publisher. The receiver is registered against the connection,
+// which is only closed when the connection itself drops, so we re-subscribe on
+// the new connection after a reconnect.
+//
+// The receiver MUST be buffered: amqp091-go delivers blocked/unblocked events
+// synchronously from the single connection-reader goroutine, fanning out to
+// every registered receiver with a blocking send. An unbuffered (or full)
+// receiver therefore wedges the reader, which then never processes the
+// connection.unblocked frame — leaving every publisher on the connection paused
+// forever. That wedge is the root cause of ENG-1846.
 func (publisher *Publisher) startNotifyBlockedHandler() {
-	blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking))
-	publisher.disablePublishDueToBlockedMu.Lock()
-	publisher.disablePublishDueToBlocked = false
-	publisher.disablePublishDueToBlockedMu.Unlock()
-
 	for {
 		select {
 		case <-publisher.done:
 			return
+		default:
+		}
+
+		blockings := publisher.connManager.NotifyBlockedSafe(make(chan amqp.Blocking, 1))
+		publisher.setBlocked(false)
+
+		if !publisher.consumeBlockings(blockings) {
+			return // publisher closed
+		}
+
+		// Receiver closed (connection dropped). Pause before re-subscribing on
+		// the reconnected connection.
+		if !publisher.waitBeforeResubscribe() {
+			return
+		}
+	}
+}
+
+// consumeFlow drains flow notifications until either the publisher is closed
+// (returns false) or the receiver is closed by a reconnect (returns true,
+// signalling the caller to re-subscribe).
+func (publisher *Publisher) consumeFlow(notifyFlowChan <-chan bool) (resubscribe bool) {
+	for {
+		select {
+		case <-publisher.done:
+			return false
+		case ok, open := <-notifyFlowChan:
+			if !open {
+				return true
+			}
+			if ok {
+				publisher.options.Logger.Warnf("pausing publishing due to flow request from server")
+			} else {
+				publisher.options.Logger.Warnf("resuming publishing due to flow request from server")
+			}
+			publisher.setFlow(ok)
+		}
+	}
+}
+
+// consumeBlockings drains connection.blocked / connection.unblocked
+// notifications until either the publisher is closed (returns false) or the
+// receiver is closed by a reconnect (returns true, signalling the caller to
+// re-subscribe).
+func (publisher *Publisher) consumeBlockings(blockings <-chan amqp.Blocking) (resubscribe bool) {
+	for {
+		select {
+		case <-publisher.done:
+			return false
 		case b, open := <-blockings:
 			if !open {
-				return
+				return true
 			}
-			publisher.disablePublishDueToBlockedMu.Lock()
 			if b.Active {
 				publisher.options.Logger.Warnf("pausing publishing due to TCP blocking from server")
-				publisher.disablePublishDueToBlocked = true
 			} else {
-				publisher.disablePublishDueToBlocked = false
 				publisher.options.Logger.Warnf("resuming publishing due to TCP blocking from server")
 			}
-			publisher.disablePublishDueToBlockedMu.Unlock()
+			publisher.setBlocked(b.Active)
 		}
+	}
+}
+
+// setFlow updates whether publishing is disabled due to a channel flow request.
+func (publisher *Publisher) setFlow(disabled bool) {
+	publisher.disablePublishDueToFlowMu.Lock()
+	defer publisher.disablePublishDueToFlowMu.Unlock()
+	publisher.disablePublishDueToFlow = disabled
+}
+
+// setBlocked updates whether publishing is disabled due to a connection block.
+func (publisher *Publisher) setBlocked(disabled bool) {
+	publisher.disablePublishDueToBlockedMu.Lock()
+	defer publisher.disablePublishDueToBlockedMu.Unlock()
+	publisher.disablePublishDueToBlocked = disabled
+}
+
+// waitBeforeResubscribe pauses between re-subscription attempts, returning false
+// if the publisher is closed while waiting.
+func (publisher *Publisher) waitBeforeResubscribe() (keepGoing bool) {
+	wait := max(publisher.connManager.ReconnectInterval, minResubscribeWait)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-publisher.done:
+		return false
+	case <-timer.C:
+		return true
 	}
 }


### PR DESCRIPTION
Opened against the wrong repo by mistake — closing.