### PR TITLE
Support reliable publishing with per-message outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,42 @@ if err != nil {
 }
 ```
 
+## Reliable publishing with per-message outcomes
+
+To know the fate of each published message — confirmed, nacked, or returned as
+unroutable — use `PublishWithOutcome` on a publisher created with
+`WithPublisherOptionsConfirm`. Unlike consuming `NotifyPublish` and
+`NotifyReturn` as separate streams, it pairs each message's confirmation with
+its return reliably, even with many messages in flight, so you can republish
+exactly the failed subset of a batch:
+
+```go
+outcomes, err := publisher.PublishWithOutcome(
+	ctx,
+	[]byte("hello, world"),
+	[]string{"my_routing_key"},
+	rabbitmq.WithPublishOptionsExchange("events"),
+	rabbitmq.WithPublishOptionsMandatory, // required to detect unroutable messages
+)
+if err != nil {
+	log.Println(err)
+}
+for _, po := range outcomes {
+	outcome, err := po.Wait(ctx)
+	if err != nil {
+		log.Println(err)
+	} else if outcome.Failed() {
+		// nacked, returned as unroutable, or unknown (channel lost mid-flight):
+		// republish, but see ErrOutcomeUnknown about possible duplicates
+	}
+}
+```
+
+Use `WithPublisherOptionsMaxOutcomesInFlight` to bound memory by limiting how
+many outcomes may be unresolved at once. See
+[examples/publisher_outcome](examples/publisher_outcome) for a complete batch
+publish-and-retry example.
+
 ## Other usage examples
 
 See the [examples](examples) directory for more ideas.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,59 @@ for _, po := range outcomes {
 ```
 
 Use `WithPublisherOptionsMaxOutcomesInFlight` to bound memory by limiting how
-many outcomes may be unresolved at once. See
-[examples/publisher_outcome](examples/publisher_outcome) for a complete batch
+many outcomes may be unresolved at once.
+
+### Correlating outcomes with your data
+
+An `Outcome` reports `ID`, `Exchange`, `RoutingKey` and `DeliveryTag`, but not
+the payload — only a message the broker returned as unroutable carries its body
+back, on `Return.Body`. To act on a failure you usually need your own record of
+it, so attach one with `WithPublishOptionsOutcomeRef` and read it back from
+`Outcome.Ref`:
+
+```go
+outcomes, err := publisher.PublishWithOutcome(
+	ctx,
+	row.Body,
+	[]string{row.RoutingKey},
+	rabbitmq.WithPublishOptionsMandatory,
+	rabbitmq.WithPublishOptionsOutcomeRef(row), // your value, echoed back
+)
+if err != nil {
+	log.Println(err)
+}
+for _, po := range outcomes {
+	outcome, err := po.Wait(ctx)
+	if err != nil {
+		log.Println(err)
+	}
+	if outcome.Failed() {
+		row := outcome.Ref.(*Row) // republish it, or mark it in your database
+		log.Printf("row %d failed: %v", row.ID, outcome.Err)
+	}
+}
+```
+
+The ref is opaque to the library and is never sent to the broker — unlike
+`CorrelationID`, which is an AMQP property your consumers can see. It is held
+only until the outcome resolves, so `WithPublisherOptionsMaxOutcomesInFlight`
+bounds how much it can retain. Every outcome of one call carries the same ref;
+use `RoutingKey` to tell them apart, and `PublishOutcome.Ref` to read it before
+the outcome resolves.
+
+A few other things worth knowing:
+
+- `Outcome.ID` is the value the library puts on the wire as the
+  `x-gorabbitmq-outcome-id` header, so you can match a publisher outcome against
+  the delivery your consumer received. Prefer it over `DeliveryTag`, which is
+  per-channel and restarts at 1 after a reconnect.
+- If you would rather keep the correlation statically typed, `*PublishOutcome` is
+  a unique handle and works as a map key: `map[*PublishOutcome]*Row`.
+- When `Wait` returns a context error the message is still in flight. The
+  returned `Outcome` carries the identity and ref anyway, with `Err` set to the
+  context error, so you can record which message you stopped waiting on.
+
+See [examples/publisher_outcome](examples/publisher_outcome) for a complete batch
 publish-and-retry example.
 
 ## Other usage examples

--- a/examples/publisher_outcome/main.go
+++ b/examples/publisher_outcome/main.go
@@ -33,11 +33,23 @@ func deleteQueues(url string, names ...string) error {
 	return nil
 }
 
-// This example publishes a batch of messages and collects the ones that need
-// to be republished: nacked, returned as unroutable, or lost to a reconnect.
+// message is this example's own record of what it published. It is attached to
+// each publishing with WithPublishOptionsOutcomeRef and handed back on the
+// Outcome, which is what makes the retry loop below possible: an Outcome on its
+// own carries no payload unless the broker returned the message.
+type message struct {
+	id         int
+	body       []byte
+	routingKey string
+}
+
+// This example publishes a batch of messages and republishes the ones that
+// failed: nacked, returned as unroutable, or lost to a reconnect.
 // Confirmations and returns are paired per message by the library, so the
 // failed set is exact even with the whole batch in flight: expect the 50
 // messages aimed at no_such_queue to fail and the other 450 to be delivered.
+// Each failure identifies itself, so the retry needs no bookkeeping tying
+// outcomes back to payloads.
 func main() {
 	const url = "amqp://guest:guest@localhost"
 
@@ -92,17 +104,19 @@ func main() {
 
 	var outcomes []*rabbitmq.PublishOutcome
 	for i := range 500 {
-		routingKey := "my_queue"
+		msg := &message{id: i, body: []byte(fmt.Sprintf("message %d", i)), routingKey: "my_queue"}
 		if i%10 == 0 {
-			routingKey = "no_such_queue" // simulate unroutable messages
+			msg.routingKey = "no_such_queue" // simulate unroutable messages
 		}
 		batch, err := publisher.PublishWithOutcome(
 			ctx,
-			[]byte(fmt.Sprintf("message %d", i)),
-			[]string{routingKey},
+			msg.body,
+			[]string{msg.routingKey},
 			// mandatory is required for the broker to return unroutable
 			// messages instead of silently dropping them
 			rabbitmq.WithPublishOptionsMandatory,
+			// hands msg back on the outcome, so a failure knows what it was
+			rabbitmq.WithPublishOptionsOutcomeRef(msg),
 		)
 		if err != nil {
 			log.Fatalf("publish %d: %v", i, err)
@@ -110,6 +124,8 @@ func main() {
 		outcomes = append(outcomes, batch...)
 	}
 
+	// the failed outcomes can be collected and carried around on their own:
+	// each one still identifies its message
 	var failed []rabbitmq.Outcome
 	for _, po := range outcomes {
 		outcome, err := po.Wait(ctx)
@@ -122,16 +138,49 @@ func main() {
 	}
 
 	log.Printf("%d of %d messages need to be republished", len(failed), len(outcomes))
+
+	var retries []*rabbitmq.PublishOutcome
 	for _, outcome := range failed {
+		msg := outcome.Ref.(*message)
+		routingKey := msg.routingKey
 		switch {
 		case outcome.Err != nil:
 			// channel was lost mid-flight: the message may have been
-			// delivered, republish only if consumers deduplicate
-			log.Printf("outcome unknown for key %s (tag %d)", outcome.RoutingKey, outcome.DeliveryTag)
+			// delivered, so republishing it can duplicate it
+			log.Printf("message %d: outcome unknown (%s), republishing anyway", msg.id, outcome.ID)
 		case outcome.Return != nil:
-			log.Printf("unroutable: key %s, reply %s", outcome.Return.RoutingKey, outcome.Return.ReplyText)
+			// the same routing key would be unroutable again, so a real app
+			// would send it somewhere that exists or park it for inspection
+			log.Printf("message %d: unroutable (%s), rerouting to my_queue", msg.id, outcome.Return.ReplyText)
+			routingKey = "my_queue"
 		default:
-			log.Printf("nacked by broker: key %s (tag %d)", outcome.RoutingKey, outcome.DeliveryTag)
+			log.Printf("message %d: nacked by the broker, republishing", msg.id)
+		}
+
+		batch, err := publisher.PublishWithOutcome(
+			ctx,
+			msg.body,
+			[]string{routingKey},
+			rabbitmq.WithPublishOptionsExchange(outcome.Exchange),
+			rabbitmq.WithPublishOptionsMandatory,
+			rabbitmq.WithPublishOptionsOutcomeRef(msg),
+		)
+		if err != nil {
+			log.Fatalf("republish of message %d: %v", msg.id, err)
+		}
+		retries = append(retries, batch...)
+	}
+
+	stillFailed := 0
+	for _, po := range retries {
+		outcome, err := po.Wait(ctx)
+		if err != nil {
+			log.Fatalf("waiting for retry outcomes: %v", err)
+		}
+		if outcome.Failed() {
+			stillFailed++
+			log.Printf("message %d still failed after retry: %+v", outcome.Ref.(*message).id, outcome)
 		}
 	}
+	log.Printf("republished %d messages, %d still failed", len(retries), stillFailed)
 }

--- a/examples/publisher_outcome/main.go
+++ b/examples/publisher_outcome/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	rabbitmq "github.com/wagslane/go-rabbitmq"
+)
+
+// deleteQueues removes leftovers from earlier runs so the example starts from
+// a known state: no_such_queue must not exist for the unroutable simulation
+// to hold, and my_queue may still hold unconsumed messages. go-rabbitmq has
+// no queue admin API, so this uses the underlying amqp client. Deleting a
+// queue that doesn't exist is a no-op.
+func deleteQueues(url string, names ...string) error {
+	conn, err := amqp.Dial(url)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	ch, err := conn.Channel()
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if _, err := ch.QueueDelete(name, false, false, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// This example publishes a batch of messages and collects the ones that need
+// to be republished: nacked, returned as unroutable, or lost to a reconnect.
+// Confirmations and returns are paired per message by the library, so the
+// failed set is exact even with the whole batch in flight: expect the 50
+// messages aimed at no_such_queue to fail and the other 450 to be delivered.
+func main() {
+	const url = "amqp://guest:guest@localhost"
+
+	if err := deleteQueues(url, "no_such_queue", "my_queue"); err != nil {
+		log.Fatal(err)
+	}
+
+	conn, err := rabbitmq.NewConn(
+		url,
+		rabbitmq.WithConnectionOptionsLogging,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	// the consumer declares my_queue and drains it; without the queue every
+	// message would be unroutable, not just the no_such_queue ones
+	// durable: recent RabbitMQ versions refuse transient non-exclusive queues
+	consumer, err := rabbitmq.NewConsumer(conn, "my_queue",
+		rabbitmq.WithConsumerOptionsLogging,
+		rabbitmq.WithConsumerOptionsQueueDurable,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer consumer.Close()
+	go func() {
+		if err := consumer.Run(func(d rabbitmq.Delivery) rabbitmq.Action {
+			return rabbitmq.Ack
+		}); err != nil {
+			log.Println("consumer stopped:", err)
+		}
+	}()
+	// give the consumer a moment to declare the queue before publishing
+	time.Sleep(time.Second)
+
+	publisher, err := rabbitmq.NewPublisher(
+		conn,
+		rabbitmq.WithPublisherOptionsLogging,
+		rabbitmq.WithPublisherOptionsConfirm,
+		// bounds memory: at most 64 messages awaiting their outcome at once
+		rabbitmq.WithPublisherOptionsMaxOutcomesInFlight(64),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer publisher.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var outcomes []*rabbitmq.PublishOutcome
+	for i := range 500 {
+		routingKey := "my_queue"
+		if i%10 == 0 {
+			routingKey = "no_such_queue" // simulate unroutable messages
+		}
+		batch, err := publisher.PublishWithOutcome(
+			ctx,
+			[]byte(fmt.Sprintf("message %d", i)),
+			[]string{routingKey},
+			// mandatory is required for the broker to return unroutable
+			// messages instead of silently dropping them
+			rabbitmq.WithPublishOptionsMandatory,
+		)
+		if err != nil {
+			log.Fatalf("publish %d: %v", i, err)
+		}
+		outcomes = append(outcomes, batch...)
+	}
+
+	var failed []rabbitmq.Outcome
+	for _, po := range outcomes {
+		outcome, err := po.Wait(ctx)
+		if err != nil {
+			log.Fatalf("waiting for outcomes: %v", err)
+		}
+		if outcome.Failed() {
+			failed = append(failed, outcome)
+		}
+	}
+
+	log.Printf("%d of %d messages need to be republished", len(failed), len(outcomes))
+	for _, outcome := range failed {
+		switch {
+		case outcome.Err != nil:
+			// channel was lost mid-flight: the message may have been
+			// delivered, republish only if consumers deduplicate
+			log.Printf("outcome unknown for key %s (tag %d)", outcome.RoutingKey, outcome.DeliveryTag)
+		case outcome.Return != nil:
+			log.Printf("unroutable: key %s, reply %s", outcome.Return.RoutingKey, outcome.Return.ReplyText)
+		default:
+			log.Printf("nacked by broker: key %s (tag %d)", outcome.RoutingKey, outcome.DeliveryTag)
+		}
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -2,6 +2,7 @@ package rabbitmq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -403,5 +404,213 @@ func TestConnCloseDuringReconnectStaysClosed(t *testing.T) {
 			t.Fatal("closed connection reconnected to the restarted broker")
 		}
 		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestPublishWithOutcomeExactFailedSet pipelines a large mixed batch of
+// routable and unroutable mandatory messages and asserts the failed set is
+// reconstructed exactly, with each returned message paired with its own
+// return (verified by body), regardless of confirmation interleaving.
+func TestPublishWithOutcomeExactFailedSet(t *testing.T) {
+	const messageCount = 400
+
+	connStr := prepareDockerTest(t)
+	conn := waitForHealthyAmqp(t, connStr)
+	defer conn.Close()
+
+	queueName := "outcome_queue"
+	consumer, err := NewConsumer(conn, queueName, WithConsumerOptionsLogger(simpleLogF(t.Logf)))
+	if err != nil {
+		t.Fatal("error creating consumer", err)
+	}
+	defer consumer.CloseWithContext(context.Background())
+	go func() {
+		_ = consumer.Run(func(d Delivery) Action { return Ack })
+	}()
+
+	publisher, err := NewPublisher(conn,
+		WithPublisherOptionsLogger(simpleLogF(t.Logf)),
+		WithPublisherOptionsConfirm,
+		WithPublisherOptionsMaxOutcomesInFlight(64),
+	)
+	if err != nil {
+		t.Fatal("error creating publisher", err)
+	}
+	defer publisher.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var outcomes []*PublishOutcome
+	var wantFailed []bool
+	for i := range messageCount {
+		unroutable := i%5 == 0
+		routingKey := queueName
+		if unroutable {
+			routingKey = "no-such-queue"
+		}
+		body := []byte(fmt.Sprintf("message-%d", i))
+		batch, err := publisher.PublishWithOutcome(ctx, body, []string{routingKey}, WithPublishOptionsMandatory)
+		if err != nil {
+			t.Fatalf("publish %d failed: %v", i, err)
+		}
+		outcomes = append(outcomes, batch...)
+		wantFailed = append(wantFailed, unroutable)
+	}
+
+	for i, po := range outcomes {
+		outcome, err := po.Wait(ctx)
+		if err != nil {
+			t.Fatalf("message %d: timed out waiting for outcome: %v", i, err)
+		}
+		if outcome.Err != nil {
+			t.Fatalf("message %d: unexpected outcome error: %v", i, outcome.Err)
+		}
+		if outcome.Failed() != wantFailed[i] {
+			t.Fatalf("message %d: Failed() = %v, want %v (outcome %+v)", i, outcome.Failed(), wantFailed[i], outcome)
+		}
+		if wantFailed[i] {
+			if !outcome.Ack || outcome.Return == nil {
+				t.Fatalf("message %d: unroutable message should be acked with a return, got %+v", i, outcome)
+			}
+			if got, want := string(outcome.Return.Body), fmt.Sprintf("message-%d", i); got != want {
+				t.Fatalf("message %d: return mis-paired, body %q, want %q", i, got, want)
+			}
+		}
+	}
+}
+
+// TestPublishWithOutcomeNonMandatory documents that without the Mandatory
+// option the broker silently drops unroutable messages and still confirms
+// them, so the outcome cannot detect the routing failure.
+func TestPublishWithOutcomeNonMandatory(t *testing.T) {
+	connStr := prepareDockerTest(t)
+	conn := waitForHealthyAmqp(t, connStr)
+	defer conn.Close()
+
+	publisher, err := NewPublisher(conn,
+		WithPublisherOptionsLogger(simpleLogF(t.Logf)),
+		WithPublisherOptionsConfirm,
+	)
+	if err != nil {
+		t.Fatal("error creating publisher", err)
+	}
+	defer publisher.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	batch, err := publisher.PublishWithOutcome(ctx, []byte("dropped"), []string{"no-such-queue"})
+	if err != nil {
+		t.Fatal("publish failed", err)
+	}
+	outcome, err := batch[0].Wait(ctx)
+	if err != nil {
+		t.Fatal("timed out waiting for outcome", err)
+	}
+	if outcome.Failed() || !outcome.Ack || outcome.Return != nil {
+		t.Fatalf("non-mandatory unroutable message should be a clean ack, got %+v", outcome)
+	}
+}
+
+// TestPublishWithOutcomeChannelReconnect forces a channel-level reconnect
+// with a batch in flight: every outcome must still resolve (as an ack or as
+// ErrOutcomeUnknown, never hang), and after the reconnect both confirmations
+// and returns must keep flowing on the replacement channel.
+func TestPublishWithOutcomeChannelReconnect(t *testing.T) {
+	const messageCount = 100
+
+	connStr := prepareDockerTest(t)
+	conn := waitForHealthyAmqp(t, connStr, WithConnectionOptionsBaseReconnectInterval(10*time.Millisecond))
+	defer conn.Close()
+
+	queueName := "outcome_reconnect_queue"
+	consumer, err := NewConsumer(conn, queueName, WithConsumerOptionsLogger(simpleLogF(t.Logf)))
+	if err != nil {
+		t.Fatal("error creating consumer", err)
+	}
+	defer consumer.CloseWithContext(context.Background())
+	go func() {
+		_ = consumer.Run(func(d Delivery) Action { return Ack })
+	}()
+
+	publisher, err := NewPublisher(conn,
+		WithPublisherOptionsLogger(simpleLogF(t.Logf)),
+		WithPublisherOptionsConfirm,
+	)
+	if err != nil {
+		t.Fatal("error creating publisher", err)
+	}
+	defer publisher.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var outcomes []*PublishOutcome
+	for i := range messageCount {
+		batch, err := publisher.PublishWithOutcome(ctx, []byte("in-flight"), []string{queueName}, WithPublishOptionsMandatory)
+		if err != nil {
+			t.Fatalf("publish %d failed: %v", i, err)
+		}
+		outcomes = append(outcomes, batch...)
+	}
+
+	// force a channel-level close while confirmations are in flight
+	reconnectionCount := publisher.chanManager.GetReconnectionCount()
+	_ = publisher.Publish([]byte("boom"), []string{"unused"}, WithPublishOptionsExchange("missing-exchange"))
+	deadline := time.Now().Add(10 * time.Second)
+	for publisher.chanManager.GetReconnectionCount() == reconnectionCount {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for channel reconnect")
+		}
+		runtime.Gosched()
+	}
+
+	unknown := 0
+	for i, po := range outcomes {
+		outcome, err := po.Wait(ctx)
+		if err != nil {
+			t.Fatalf("message %d: outcome hung across reconnect: %v", i, err)
+		}
+		switch {
+		case outcome.Err != nil:
+			if !errors.Is(outcome.Err, ErrOutcomeUnknown) {
+				t.Fatalf("message %d: unexpected error %v", i, outcome.Err)
+			}
+			unknown++
+		case outcome.Ack && outcome.Return == nil:
+			// confirmed before the channel died
+		default:
+			t.Fatalf("message %d: unexpected outcome %+v", i, outcome)
+		}
+	}
+	t.Logf("%d of %d in-flight outcomes resolved as unknown across the reconnect", unknown, messageCount)
+
+	// publishing gates on the returns listener covering the new channel, so
+	// the very first post-reconnect unroutable publish must resolve with its
+	// return; a clean ack here would be a silently false success
+	batch, err := publisher.PublishWithOutcome(ctx, []byte("post-reconnect"), []string{"no-such-queue"}, WithPublishOptionsMandatory)
+	if err != nil {
+		t.Fatalf("publish after reconnect failed: %v", err)
+	}
+	outcome, err := batch[0].Wait(ctx)
+	if err != nil {
+		t.Fatal("timed out waiting for post-reconnect outcome", err)
+	}
+	if !outcome.Ack || outcome.Return == nil || outcome.Err != nil {
+		t.Fatalf("post-reconnect unroutable message must carry its return, got %+v", outcome)
+	}
+
+	// and routable messages must confirm cleanly
+	batch, err = publisher.PublishWithOutcome(ctx, []byte("routable"), []string{queueName}, WithPublishOptionsMandatory)
+	if err != nil {
+		t.Fatal("routable publish after reconnect failed", err)
+	}
+	outcome, err = batch[0].Wait(ctx)
+	if err != nil {
+		t.Fatal("timed out waiting for routable outcome", err)
+	}
+	if outcome.Failed() {
+		t.Fatalf("routable message after reconnect should succeed, got %+v", outcome)
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -411,6 +411,36 @@ func TestConnCloseDuringReconnectStaysClosed(t *testing.T) {
 // routable and unroutable mandatory messages and asserts the failed set is
 // reconstructed exactly, with each returned message paired with its own
 // return (verified by body), regardless of confirmation interleaving.
+// probeBody is the payload waitForRoutable publishes. Handlers in these tests
+// skip it so it does not count towards delivery assertions.
+const probeBody = "routability-probe"
+
+// waitForRoutable blocks until a mandatory publish to exchange/routingKey is no
+// longer returned as unroutable. A consumer declares its queue and bindings
+// inside Run, which the tests start in a goroutine, so without this the first
+// messages of a batch can be genuinely unroutable and the failed set is larger
+// than the test intends.
+func waitForRoutable(ctx context.Context, t *testing.T, publisher *Publisher, exchange, routingKey string) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		batch, err := publisher.PublishWithOutcome(ctx, []byte(probeBody), []string{routingKey},
+			WithPublishOptionsExchange(exchange),
+			WithPublishOptionsMandatory,
+		)
+		if err == nil && len(batch) == 1 {
+			outcome, waitErr := batch[0].Wait(ctx)
+			if waitErr == nil && !outcome.Failed() {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("routing key %q on exchange %q never became routable", routingKey, exchange)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 func TestPublishWithOutcomeExactFailedSet(t *testing.T) {
 	const messageCount = 400
 
@@ -441,42 +471,231 @@ func TestPublishWithOutcomeExactFailedSet(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	waitForRoutable(ctx, t, publisher, "", queueName)
+
+	// the ref carries what the assertions need, so the test keeps no parallel
+	// index from outcomes back to messages
+	type sent struct {
+		index      int
+		body       []byte
+		unroutable bool
+	}
+
 	var outcomes []*PublishOutcome
-	var wantFailed []bool
 	for i := range messageCount {
-		unroutable := i%5 == 0
+		msg := &sent{
+			index:      i,
+			body:       []byte(fmt.Sprintf("message-%d", i)),
+			unroutable: i%5 == 0,
+		}
 		routingKey := queueName
-		if unroutable {
+		if msg.unroutable {
 			routingKey = "no-such-queue"
 		}
-		body := []byte(fmt.Sprintf("message-%d", i))
-		batch, err := publisher.PublishWithOutcome(ctx, body, []string{routingKey}, WithPublishOptionsMandatory)
+		batch, err := publisher.PublishWithOutcome(ctx, msg.body, []string{routingKey},
+			WithPublishOptionsMandatory,
+			WithPublishOptionsOutcomeRef(msg),
+		)
 		if err != nil {
 			t.Fatalf("publish %d failed: %v", i, err)
 		}
 		outcomes = append(outcomes, batch...)
-		wantFailed = append(wantFailed, unroutable)
 	}
 
-	for i, po := range outcomes {
+	seenIDs := make(map[string]int, messageCount)
+	for _, po := range outcomes {
 		outcome, err := po.Wait(ctx)
 		if err != nil {
-			t.Fatalf("message %d: timed out waiting for outcome: %v", i, err)
+			t.Fatalf("timed out waiting for outcome %s: %v", outcome.ID, err)
+		}
+		msg, ok := outcome.Ref.(*sent)
+		if !ok {
+			t.Fatalf("outcome %+v did not carry its ref", outcome)
 		}
 		if outcome.Err != nil {
-			t.Fatalf("message %d: unexpected outcome error: %v", i, outcome.Err)
+			t.Fatalf("message %d: unexpected outcome error: %v", msg.index, outcome.Err)
 		}
-		if outcome.Failed() != wantFailed[i] {
-			t.Fatalf("message %d: Failed() = %v, want %v (outcome %+v)", i, outcome.Failed(), wantFailed[i], outcome)
+		if outcome.Failed() != msg.unroutable {
+			t.Fatalf("message %d: Failed() = %v, want %v (outcome %+v)", msg.index, outcome.Failed(), msg.unroutable, outcome)
 		}
-		if wantFailed[i] {
+		if outcome.ID == "" {
+			t.Fatalf("message %d: outcome carries no ID", msg.index)
+		}
+		if prev, dup := seenIDs[outcome.ID]; dup {
+			t.Fatalf("outcome ID %q reused by messages %d and %d", outcome.ID, prev, msg.index)
+		}
+		seenIDs[outcome.ID] = msg.index
+		// published to the default exchange
+		if outcome.Exchange != "" {
+			t.Fatalf("message %d: Exchange = %q, want the default exchange", msg.index, outcome.Exchange)
+		}
+		if msg.unroutable {
 			if !outcome.Ack || outcome.Return == nil {
-				t.Fatalf("message %d: unroutable message should be acked with a return, got %+v", i, outcome)
+				t.Fatalf("message %d: unroutable message should be acked with a return, got %+v", msg.index, outcome)
 			}
-			if got, want := string(outcome.Return.Body), fmt.Sprintf("message-%d", i); got != want {
-				t.Fatalf("message %d: return mis-paired, body %q, want %q", i, got, want)
+			if got, want := string(outcome.Return.Body), string(msg.body); got != want {
+				t.Fatalf("message %d: return mis-paired, body %q, want %q", msg.index, got, want)
 			}
 		}
+	}
+	if len(seenIDs) != messageCount {
+		t.Fatalf("resolved %d outcomes, want %d", len(seenIDs), messageCount)
+	}
+}
+
+// TestPublishWithOutcomeRepublishFailedSet is the acceptance test for acting on
+// the failed set: the failed outcomes are collected as plain Outcome values,
+// detached from the futures that produced them, and are still enough to
+// republish every message. Note that the test keeps no map from outcomes back
+// to messages - that is the point.
+func TestPublishWithOutcomeRepublishFailedSet(t *testing.T) {
+	const (
+		messageCount = 120
+		exchangeName = "outcome_retry_exchange"
+	)
+
+	connStr := prepareDockerTest(t)
+	conn := waitForHealthyAmqp(t, connStr)
+	defer conn.Close()
+
+	queueName := "outcome_retry_queue"
+
+	var mu sync.Mutex
+	delivered := map[string]int{}
+	consumer, err := NewConsumer(conn, queueName,
+		WithConsumerOptionsLogger(simpleLogF(t.Logf)),
+		WithConsumerOptionsExchangeName(exchangeName),
+		WithConsumerOptionsExchangeDeclare,
+		WithConsumerOptionsRoutingKey(queueName),
+	)
+	if err != nil {
+		t.Fatal("error creating consumer", err)
+	}
+	defer consumer.CloseWithContext(context.Background())
+	go func() {
+		_ = consumer.Run(func(d Delivery) Action {
+			if string(d.Body) != probeBody {
+				mu.Lock()
+				delivered[string(d.Body)]++
+				mu.Unlock()
+			}
+			return Ack
+		})
+	}()
+
+	publisher, err := NewPublisher(conn,
+		WithPublisherOptionsLogger(simpleLogF(t.Logf)),
+		WithPublisherOptionsConfirm,
+		WithPublisherOptionsExchangeName(exchangeName),
+		WithPublisherOptionsExchangeDeclare,
+		WithPublisherOptionsMaxOutcomesInFlight(32),
+	)
+	if err != nil {
+		t.Fatal("error creating publisher", err)
+	}
+	defer publisher.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	waitForRoutable(ctx, t, publisher, exchangeName, queueName)
+
+	// half the batch is aimed at a routing key nothing is bound to
+	wantRetried := map[string]bool{}
+	wantRouted := map[string]bool{}
+	var outcomes []*PublishOutcome
+	for i := range messageCount {
+		body := fmt.Sprintf("routed-%d", i)
+		routingKey := queueName
+		if i%2 == 0 {
+			body = fmt.Sprintf("unrouted-%d", i)
+			routingKey = "no-such-binding"
+			wantRetried[body] = true
+		} else {
+			wantRouted[body] = true
+		}
+		batch, err := publisher.PublishWithOutcome(ctx, []byte(body), []string{routingKey},
+			WithPublishOptionsExchange(exchangeName),
+			WithPublishOptionsMandatory,
+			WithPublishOptionsOutcomeRef([]byte(body)),
+		)
+		if err != nil {
+			t.Fatalf("publish %d failed: %v", i, err)
+		}
+		outcomes = append(outcomes, batch...)
+	}
+
+	var failed []Outcome
+	for _, po := range outcomes {
+		outcome, err := po.Wait(ctx)
+		if err != nil {
+			t.Fatalf("timed out waiting for outcome %s: %v", outcome.ID, err)
+		}
+		if outcome.Failed() {
+			failed = append(failed, outcome)
+		}
+	}
+	if len(failed) != len(wantRetried) {
+		t.Fatalf("failed set has %d outcomes, want %d", len(failed), len(wantRetried))
+	}
+
+	// republish from the outcomes alone: Exchange says where the message
+	// belonged and Ref carries the payload back
+	var retries []*PublishOutcome
+	for _, outcome := range failed {
+		body, ok := outcome.Ref.([]byte)
+		if !ok {
+			t.Fatalf("failed outcome %+v did not carry its ref", outcome)
+		}
+		if !wantRetried[string(body)] {
+			t.Fatalf("unexpected message in the failed set: %q", body)
+		}
+		batch, err := publisher.PublishWithOutcome(ctx, body, []string{queueName},
+			WithPublishOptionsExchange(outcome.Exchange),
+			WithPublishOptionsMandatory,
+		)
+		if err != nil {
+			t.Fatalf("republish of %q failed: %v", body, err)
+		}
+		retries = append(retries, batch...)
+	}
+
+	for _, po := range retries {
+		outcome, err := po.Wait(ctx)
+		if err != nil {
+			t.Fatalf("timed out waiting for retry outcome %s: %v", outcome.ID, err)
+		}
+		if outcome.Failed() {
+			t.Fatalf("republished message still failed: %+v", outcome)
+		}
+	}
+
+	// every originally-routed message and every retried message arrives once
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		mu.Lock()
+		count := len(delivered)
+		mu.Unlock()
+		if count >= len(wantRouted)+len(wantRetried) || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for body := range wantRetried {
+		if delivered[body] != 1 {
+			t.Errorf("retried message %q delivered %d times, want 1", body, delivered[body])
+		}
+	}
+	for body := range wantRouted {
+		if delivered[body] != 1 {
+			t.Errorf("routed message %q delivered %d times, want 1", body, delivered[body])
+		}
+	}
+	if len(delivered) != len(wantRouted)+len(wantRetried) {
+		t.Errorf("consumer saw %d distinct bodies, want %d", len(delivered), len(wantRouted)+len(wantRetried))
 	}
 }
 

--- a/internal/channelmanager/channel_manager.go
+++ b/internal/channelmanager/channel_manager.go
@@ -118,7 +118,6 @@ func (chanManager *ChannelManager) reconnectLoop() {
 		if err != nil {
 			chanManager.logger.Errorf("error reconnecting to amqp server: %v", err)
 		} else {
-			chanManager.incrementReconnectionCount()
 			go chanManager.startNotifyCancelOrClosed()
 			return
 		}
@@ -151,6 +150,14 @@ func (chanManager *ChannelManager) reconnect() error {
 	}
 
 	chanManager.channel = newChannel
+	// The count must advance before channelMu is released so that any
+	// operation that can reach the new channel also observes the new count.
+	// PublishWithOutcome keys its returns-listener gate on this coupling:
+	// incrementing after the unlock would let a publish go out on the new
+	// channel (which has no returns listener yet) while the count still
+	// reports the old generation, and an unroutable mandatory message
+	// published in that window would resolve as a false success.
+	chanManager.incrementReconnectionCount()
 	return nil
 }
 

--- a/internal/channelmanager/reconnect_test.go
+++ b/internal/channelmanager/reconnect_test.go
@@ -1,0 +1,162 @@
+package channelmanager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/wagslane/go-rabbitmq/internal/connectionmanager"
+)
+
+// prepareChannelManagerBroker launches a rabbitmq container for this package's
+// integration tests. It publishes on host port 5673 so it cannot collide with
+// the root package's integration broker on 5672 when `go test ./...` runs the
+// package test binaries in parallel.
+func prepareChannelManagerBroker(t *testing.T) string {
+	const flag = "ENABLE_DOCKER_INTEGRATION_TESTS"
+	if v, ok := os.LookupEnv(flag); !ok || strings.ToUpper(v) != "TRUE" {
+		t.Skipf("integration tests are only run if '%s' is TRUE", flag)
+		return ""
+	}
+	out, err := exec.Command("docker", "run", "--rm", "--detach", "--publish=5673:5672", "--quiet", "--", "rabbitmq:4.1.1-alpine").Output()
+	if err != nil {
+		t.Log("container id", string(out))
+		t.Fatalf("error launching rabbitmq in docker: %v", err)
+	}
+	t.Cleanup(func() {
+		containerId := strings.TrimSpace(string(out))
+		t.Logf("attempting to shutdown container '%s'", containerId)
+		if err := exec.Command("docker", "rm", "--force", containerId).Run(); err != nil {
+			t.Logf("failed to stop: %v", err)
+		}
+	})
+	return "amqp://guest:guest@localhost:5673/"
+}
+
+type staticResolver []string
+
+func (r staticResolver) Resolve() ([]string, error) { return r, nil }
+
+// discardLogger swallows manager logs: the reconnect goroutines outlive the
+// test body, and logging through testing.T after the test ends panics.
+type discardLogger struct{}
+
+func (discardLogger) Fatalf(string, ...interface{}) {}
+func (discardLogger) Errorf(string, ...interface{}) {}
+func (discardLogger) Warnf(string, ...interface{})  {}
+func (discardLogger) Infof(string, ...interface{})  {}
+func (discardLogger) Debugf(string, ...interface{}) {}
+
+// TestReconnectionCountCoupledToChannelSwap guards the coupling that
+// PublishWithOutcome's returns-listener gate depends on: the reconnection
+// count advances before a swapped-in channel becomes reachable through
+// channelMu. Probers snapshot (channel, count) under the read lock across
+// repeated forced reconnects; a snapshot pair that disagrees on the channel
+// but agrees on the count means a publish could have gone out on a channel
+// the outcome tracker's returns listener does not cover. Because the broken
+// window is only a few instructions wide, the probe is complemented by a
+// deterministic check: reconnect() holds channelMu for its whole body, so
+// requiring the count to have advanced by the time it returns pins the
+// increment inside the critical section.
+func TestReconnectionCountCoupledToChannelSwap(t *testing.T) {
+	url := prepareChannelManagerBroker(t)
+
+	log := discardLogger{}
+	var connManager *connectionmanager.ConnectionManager
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		var err error
+		connManager, err = connectionmanager.NewConnectionManager(staticResolver{url}, amqp.Config{}, log, time.Second)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("broker did not become ready: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	defer connManager.Close()
+
+	chanManager, err := NewChannelManager(connManager, log, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("creating channel manager: %v", err)
+	}
+	defer chanManager.Close()
+
+	stop := make(chan struct{})
+	violation := make(chan string, 1)
+	var probers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		probers.Add(1)
+		go func() {
+			defer probers.Done()
+			var lastChannel *amqp.Channel
+			var lastCount uint
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				chanManager.channelMu.RLock()
+				ch := chanManager.channel
+				count := chanManager.GetReconnectionCount()
+				chanManager.channelMu.RUnlock()
+				if lastChannel != nil && ch != lastChannel && count == lastCount {
+					select {
+					case violation <- fmt.Sprintf("new channel reachable while the reconnection count still reads %d", count):
+					default:
+					}
+					return
+				}
+				lastChannel, lastCount = ch, count
+				runtime.Gosched()
+			}
+		}()
+	}
+
+	for i := 0; i < 15; i++ {
+		before := chanManager.GetReconnectionCount()
+		// publishing to a missing exchange fails the channel with a 404,
+		// forcing a reconnect; the publish error itself is irrelevant
+		_ = chanManager.PublishWithContextSafe(
+			context.Background(),
+			"no-such-exchange-gorabbitmq-test", "key", false, false,
+			amqp.Publishing{Body: []byte("boom")},
+		)
+		reconnected := time.Now().Add(10 * time.Second)
+		for chanManager.GetReconnectionCount() == before {
+			if time.Now().After(reconnected) {
+				t.Fatalf("reconnect %d did not happen within 10s", i)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	close(stop)
+	probers.Wait()
+	select {
+	case msg := <-violation:
+		t.Fatal(msg)
+	default:
+	}
+
+	// the deterministic half: reconnect() must advance the count itself,
+	// under the channel lock, not leave it to a caller after the unlock.
+	// (Closing the old channel gracefully does not trigger the manager's own
+	// reconnect loop, so the +1 below can come only from reconnect itself.)
+	before := chanManager.GetReconnectionCount()
+	if err := chanManager.reconnect(); err != nil {
+		t.Fatalf("direct reconnect: %v", err)
+	}
+	if got := chanManager.GetReconnectionCount(); got != before+1 {
+		t.Fatalf("reconnection count after reconnect() = %d, want %d: the count must advance inside reconnect's critical section, before the new channel is reachable", got, before+1)
+	}
+}

--- a/publish.go
+++ b/publish.go
@@ -61,6 +61,9 @@ type Publisher struct {
 	notifyReturnHandler  func(r Return)
 	notifyPublishHandler func(p Confirmation)
 
+	outcomes     *outcomeTracker
+	outcomesOnce *sync.Once
+
 	options PublisherOptions
 }
 
@@ -104,6 +107,7 @@ func NewPublisher(conn *Conn, optionFuncs ...func(*PublisherOptions)) (*Publishe
 		done:                       make(chan struct{}),
 		blockedHandlerDone:         make(chan struct{}),
 		closeOnce:                  &sync.Once{},
+		outcomesOnce:               &sync.Once{},
 		handlerMu:                  &sync.Mutex{},
 		notifyReturnHandler:        nil,
 		notifyPublishHandler:       nil,

--- a/publish_options.go
+++ b/publish_options.go
@@ -41,6 +41,11 @@ type PublishOptions struct {
 	// Application or exchange specific fields,
 	// the headers exchange will inspect this field.
 	Headers Table
+	// OutcomeRef is an opaque caller value echoed back on every Outcome
+	// produced by a PublishWithOutcome call. It is never sent to the broker,
+	// unlike CorrelationID, which is an AMQP message property visible to
+	// consumers. The other publish methods ignore it.
+	OutcomeRef any
 }
 
 // WithPublishOptionsExchange returns a function that sets the exchange to publish to
@@ -152,5 +157,23 @@ func WithPublishOptionsUserID(userID string) func(*PublishOptions) {
 func WithPublishOptionsAppID(appID string) func(*PublishOptions) {
 	return func(options *PublishOptions) {
 		options.AppID = appID
+	}
+}
+
+// WithPublishOptionsOutcomeRef attaches an opaque caller value (a database key,
+// a struct pointer, the message itself) to a PublishWithOutcome call. The value
+// is returned unchanged as Outcome.Ref on every outcome of that call, one per
+// routing key and all sharing the same ref, so a failed Outcome can be mapped
+// back to the data it came from without keeping a parallel index. Use
+// Outcome.RoutingKey to tell the outcomes of one call apart, and
+// PublishOutcome.Ref to read the value before the outcome resolves.
+//
+// The value is held until the outcome resolves, so
+// WithPublisherOptionsMaxOutcomesInFlight bounds how much it can retain. It is
+// never sent to the broker, and Publish and PublishWithDeferredConfirmWithContext
+// ignore it.
+func WithPublishOptionsOutcomeRef(ref any) func(*PublishOptions) {
+	return func(options *PublishOptions) {
+		options.OutcomeRef = ref
 	}
 }

--- a/publish_outcome.go
+++ b/publish_outcome.go
@@ -1,0 +1,546 @@
+package rabbitmq
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// outcomeChannelManager is the subset of the channel manager the outcome
+// tracker relies on, extracted so the reconnect behavior can be tested
+// without a broker.
+type outcomeChannelManager interface {
+	GetReconnectionCount() uint
+	NotifyReturnSafe(c chan amqp.Return) chan amqp.Return
+	NotifyReconnect() (<-chan error, chan<- struct{})
+}
+
+// OutcomeIDHeader is the message header PublishWithOutcome sets on every
+// message to correlate broker returns with publisher confirmations. It is
+// visible to consumers of the message, and any caller-set value for this
+// header is overwritten.
+const OutcomeIDHeader = "x-gorabbitmq-outcome-id"
+
+// ErrOutcomeUnknown reports that the channel was lost around the time the
+// message was in flight, so its fate could not be determined. The message may
+// or may not have been delivered: republish it only if consumers tolerate
+// duplicates (e.g. by deduplicating on a message ID).
+//
+// Classification is deliberately conservative: a genuine broker nack that
+// races with a channel loss may occasionally be reported as unknown, but the
+// reverse never happens — an outcome reported as a definite ack or nack was
+// really sent by the broker on a live channel.
+var ErrOutcomeUnknown = errors.New("outcome unknown: channel closed before the broker confirmed the publishing")
+
+// ErrPublisherClosed reports that the publisher was closed before the
+// operation could complete.
+var ErrPublisherClosed = errors.New("publisher is closed")
+
+// bufferedReturnsCount is the buffer of the tracker's basic.return listener.
+// Returns only flow for mandatory/immediate messages the broker cannot
+// deliver; the buffer keeps the client's frame-dispatch goroutine from
+// blocking during bursts of unroutable messages.
+const bufferedReturnsCount = 64
+
+// Outcome is the final fate of one message published with PublishWithOutcome.
+type Outcome struct {
+	// RoutingKey the message was published with.
+	RoutingKey string
+	// DeliveryTag the channel assigned to the publishing.
+	DeliveryTag uint64
+	// Ack is true when the broker took responsibility for the message. Note
+	// that the broker acks mandatory messages it could not route (after
+	// sending the return), so a routing failure is Ack=true with a non-nil
+	// Return.
+	Ack bool
+	// Return is non-nil when the broker returned the message as unroutable.
+	// The broker only issues returns for messages published with the
+	// Mandatory (or Immediate) option; without it unroutable messages are
+	// silently dropped and confirmed.
+	Return *Return
+	// Err is non-nil when no definite outcome could be determined, see
+	// ErrOutcomeUnknown.
+	Err error
+}
+
+// Failed reports whether the message needs to be republished: the broker
+// nacked it, returned it as unroutable, or the outcome is unknown.
+func (o Outcome) Failed() bool {
+	return o.Err != nil || !o.Ack || o.Return != nil
+}
+
+// PublishOutcome resolves to the Outcome of one published message once the
+// broker has confirmed or returned it, or the channel is lost.
+type PublishOutcome struct {
+	done    chan struct{}
+	outcome Outcome
+}
+
+// Done returns a channel that is closed when the outcome is available.
+func (p *PublishOutcome) Done() <-chan struct{} {
+	return p.done
+}
+
+// Wait blocks until the outcome is available or the context is done.
+func (p *PublishOutcome) Wait(ctx context.Context) (Outcome, error) {
+	select {
+	case <-p.done:
+		return p.outcome, nil
+	case <-ctx.Done():
+		return Outcome{}, ctx.Err()
+	}
+}
+
+// deferredConfirmation is the subset of amqp.DeferredConfirmation the tracker
+// relies on, extracted so the pairing logic can be tested without a broker.
+type deferredConfirmation interface {
+	Done() <-chan struct{}
+	Acked() bool
+}
+
+type outcomeEntry struct {
+	id string
+	// gen is the tracker's channel generation observed when the message was
+	// published. It is sampled before the publish on purpose: it can only be
+	// less than or equal to the generation at any later event, so a channel
+	// death after the publish always shows up as a mismatch. A confirmation
+	// that resolves negatively under a different generation was synthesized
+	// by the client library on channel close, not sent by the broker, and is
+	// reported as ErrOutcomeUnknown.
+	gen uint64
+	// uncertain marks a publish that could not be verified to have gone out
+	// on the same channel the returns listener is installed on. For such
+	// messages the absence of a return proves nothing, so a bare ack resolves
+	// as ErrOutcomeUnknown instead of success.
+	uncertain bool
+	dc        deferredConfirmation
+	po        *PublishOutcome
+}
+
+// outcomeTracker pairs broker returns with publisher confirmations.
+//
+// All returns and all confirmation completions funnel through the single run
+// goroutine. Because the amqp library delivers a message's basic.return into
+// the returns listener strictly before it resolves that message's
+// DeferredConfirmation, draining the returns listener before processing a
+// completion guarantees the matching return has already been stashed. The
+// stash is keyed by a per-publishing ID carried in a message header, so the
+// pairing does not depend on any adjacency between returns and confirmations
+// (confirmations are resequenced by delivery tag and may be collapsed by
+// multiple-acks).
+type outcomeTracker struct {
+	chanManager   outcomeChannelManager
+	logger        Logger
+	publisherDone <-chan struct{}
+
+	idPrefix string
+	idSeq    atomic.Uint64
+
+	// gen counts channel generations; bumped by the run goroutine each time
+	// the returns listener closes (channel loss or publisher close).
+	gen atomic.Uint64
+
+	// listenerReconn is the reconnection count the returns listener is
+	// currently installed for; listenerReady is closed and replaced whenever
+	// it advances, waking publishes gated on listener currency.
+	listenerMu     sync.Mutex
+	listenerReconn uint
+	listenerReady  chan struct{}
+
+	// sem caps in-flight publishings; nil means unlimited.
+	sem chan struct{}
+
+	// completionCh must be unbuffered: a completion is either handed to the
+	// run goroutine or, if it has exited, the sender observes exited and
+	// resolves the entry itself. A buffered send could succeed after run
+	// exits and strand the entry unresolved.
+	completionCh chan *outcomeEntry
+	outstanding  atomic.Int64
+	// exited is closed when the run goroutine stops; completions that can no
+	// longer be delivered resolve conservatively as ErrOutcomeUnknown.
+	exited chan struct{}
+
+	// returned stashes broker returns by outcome ID until the matching
+	// confirmation arrives. Only the run goroutine touches it.
+	returned map[string]*Return
+}
+
+func newOutcomeTracker(
+	chanManager outcomeChannelManager,
+	logger Logger,
+	publisherDone <-chan struct{},
+	maxInFlight int,
+) *outcomeTracker {
+	prefix := make([]byte, 8)
+	if _, err := rand.Read(prefix); err != nil {
+		// fall back to the address-derived uniqueness of the tracker itself;
+		// IDs only need to be unique within one channel's lifetime
+		prefix = []byte("gorabbit")
+	}
+	tracker := &outcomeTracker{
+		chanManager:   chanManager,
+		logger:        logger,
+		publisherDone: publisherDone,
+		idPrefix:      hex.EncodeToString(prefix) + "-",
+		completionCh:  make(chan *outcomeEntry),
+		exited:        make(chan struct{}),
+		returned:      make(map[string]*Return),
+		listenerReady: make(chan struct{}),
+	}
+	if maxInFlight > 0 {
+		tracker.sem = make(chan struct{}, maxInFlight)
+	}
+	return tracker
+}
+
+// start registers the returns listener before the first publish can happen
+// and launches the pairing goroutine.
+func (t *outcomeTracker) start() {
+	reconnCh, reconnStop := t.chanManager.NotifyReconnect()
+	returns := t.registerReturnsListener()
+	go t.run(returns, reconnCh, reconnStop)
+}
+
+// registerReturnsListener installs a returns listener on the current channel
+// and records which reconnection generation it covers. The registration is
+// sandwiched between two reads of the reconnection count: when they agree,
+// the listener is installed on a channel no older than that generation (the
+// count advances only after a swap completes, so the listener can be on a
+// newer channel than recorded — which only makes the gate over-conservative,
+// never wrong). When the reads differ, it is unknown which channel the
+// listener landed on; it cannot simply be dropped, because the amqp client
+// has no listener deregistration and an unconsumed listener on the live
+// channel would eventually fill and block the connection's frame dispatch.
+// It is drained and discarded instead: discarding is safe because publishes
+// are gated while no listener is confirmed current, so no outcome returns
+// can arrive that the successful registration won't also receive.
+func (t *outcomeTracker) registerReturnsListener() <-chan amqp.Return {
+	for {
+		before := t.chanManager.GetReconnectionCount()
+		returns := t.chanManager.NotifyReturnSafe(make(chan amqp.Return, bufferedReturnsCount))
+		if t.chanManager.GetReconnectionCount() != before {
+			go discardReturns(returns)
+			continue
+		}
+		t.listenerMu.Lock()
+		t.listenerReconn = before
+		close(t.listenerReady)
+		t.listenerReady = make(chan struct{})
+		t.listenerMu.Unlock()
+		return returns
+	}
+}
+
+// discardReturns keeps a superseded listener drained until its channel dies,
+// so it can never block the connection's frame dispatch.
+func discardReturns(returns <-chan amqp.Return) {
+	for range returns {
+	}
+}
+
+// listenerStale reports whether a reconnect has outpaced the recorded
+// listener generation.
+func (t *outcomeTracker) listenerStale() bool {
+	t.listenerMu.Lock()
+	installed := t.listenerReconn
+	t.listenerMu.Unlock()
+	return installed != t.chanManager.GetReconnectionCount()
+}
+
+// awaitCurrentListener blocks until the returns listener covers the current
+// channel generation, so a publish cannot race ahead of the listener after a
+// reconnect and have its basic.return silently dropped. It returns the
+// covered generation for post-publish verification. In steady state this is
+// two cheap reads.
+func (t *outcomeTracker) awaitCurrentListener(ctx context.Context) (uint, error) {
+	for {
+		t.listenerMu.Lock()
+		installed := t.listenerReconn
+		ready := t.listenerReady
+		t.listenerMu.Unlock()
+
+		if installed == t.chanManager.GetReconnectionCount() {
+			return installed, nil
+		}
+		select {
+		case <-ready:
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-t.publisherDone:
+			return 0, ErrPublisherClosed
+		}
+	}
+}
+
+func (t *outcomeTracker) run(returns <-chan amqp.Return, reconnCh <-chan error, reconnStop chan<- struct{}) {
+	defer close(t.exited)
+	defer close(reconnStop)
+
+	done := t.publisherDone
+	doneSeen := false
+
+	for {
+		// wait for a reconnect signal while there is no live returns
+		// listener, or while the listener is stale — a registration that
+		// landed after a channel swap but before the reconnection count
+		// advanced records too old a generation, keeping the publish gate
+		// closed until re-registration
+		var reconn <-chan error
+		if (returns == nil || t.listenerStale()) && !doneSeen {
+			reconn = reconnCh
+		}
+
+		select {
+		case ret, ok := <-returns:
+			if !ok {
+				t.gen.Add(1)
+				returns = nil
+				continue
+			}
+			t.stashReturn(ret)
+
+		case <-reconn:
+			fresh := t.registerReturnsListener()
+			if returns != nil {
+				// the superseded listener may sit on the live channel:
+				// capture what it received before the replacement was
+				// registered (not yet duplicated anywhere), then keep it
+				// drained — its future traffic also reaches the replacement
+				if returns = t.drainReturns(returns); returns != nil {
+					go discardReturns(returns)
+				}
+			}
+			returns = fresh
+
+		case entry := <-t.completionCh:
+			returns = t.drainReturns(returns)
+			t.resolve(entry)
+			if doneSeen && t.outstanding.Load() == 0 {
+				return
+			}
+
+		case <-done:
+			doneSeen = true
+			done = nil
+			if t.outstanding.Load() == 0 {
+				return
+			}
+		}
+	}
+}
+
+// drainReturns consumes every immediately available return. It runs before a
+// completion is processed: the return for the completing message (if any) is
+// guaranteed to already be receivable, so after the drain the stash is
+// authoritative for that message.
+func (t *outcomeTracker) drainReturns(returns <-chan amqp.Return) <-chan amqp.Return {
+	for returns != nil {
+		select {
+		case ret, ok := <-returns:
+			if !ok {
+				t.gen.Add(1)
+				return nil
+			}
+			t.stashReturn(ret)
+		default:
+			return returns
+		}
+	}
+	return nil
+}
+
+func (t *outcomeTracker) stashReturn(ret amqp.Return) {
+	id, ok := ret.Headers[OutcomeIDHeader].(string)
+	if !ok {
+		// not published through PublishWithOutcome; the regular NotifyReturn
+		// handler is responsible for it
+		return
+	}
+	r := Return{ret}
+	t.returned[id] = &r
+}
+
+func (t *outcomeTracker) resolve(entry *outcomeEntry) {
+	po := entry.po
+	po.outcome.Return = t.returned[entry.id]
+	delete(t.returned, entry.id)
+
+	if entry.dc.Acked() {
+		po.outcome.Ack = true
+		if entry.uncertain && po.outcome.Return == nil {
+			// the publish could not be verified against the returns
+			// listener's channel, so the missing return proves nothing; a
+			// present return is positive evidence and stays definitive
+			po.outcome.Err = ErrOutcomeUnknown
+		}
+	} else if entry.gen != t.gen.Load() {
+		po.outcome.Err = ErrOutcomeUnknown
+	}
+	close(po.done)
+	t.release()
+	t.outstanding.Add(-1)
+}
+
+// await feeds the confirmation of one publishing to the run goroutine.
+func (t *outcomeTracker) await(entry *outcomeEntry) {
+	select {
+	case <-entry.dc.Done():
+	case <-t.exited:
+		t.abandon(entry)
+		return
+	}
+	select {
+	case t.completionCh <- entry:
+	case <-t.exited:
+		t.abandon(entry)
+	}
+}
+
+// abandon resolves an entry whose completion can no longer reach the run
+// goroutine. Without the stash there is no way to tell whether the message
+// was returned, so the outcome is conservatively unknown.
+func (t *outcomeTracker) abandon(entry *outcomeEntry) {
+	t.logger.Warnf("publisher closed with outcome still in flight, resolving delivery tag %d as unknown", entry.po.outcome.DeliveryTag)
+	entry.po.outcome.Err = ErrOutcomeUnknown
+	close(entry.po.done)
+	t.release()
+	t.outstanding.Add(-1)
+}
+
+func (t *outcomeTracker) acquire(ctx context.Context) error {
+	if t.sem == nil {
+		return nil
+	}
+	select {
+	case t.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.publisherDone:
+		return ErrPublisherClosed
+	}
+}
+
+func (t *outcomeTracker) release() {
+	if t.sem != nil {
+		<-t.sem
+	}
+}
+
+func (t *outcomeTracker) nextID() string {
+	return t.idPrefix + strconv.FormatUint(t.idSeq.Add(1), 10)
+}
+
+// PublishWithOutcome publishes the provided data to each routing key and
+// returns one PublishOutcome per key: a future that resolves to the message's
+// final fate once the broker confirms it, returns it as unroutable, or the
+// channel is lost. Unlike consuming NotifyPublish and NotifyReturn as
+// separate streams, the confirmation and the return of the same message are
+// paired reliably, including with many messages in flight.
+//
+// Requirements and semantics:
+//   - The publisher must be created with WithPublisherOptionsConfirm.
+//   - Detecting unroutable messages requires WithPublishOptionsMandatory;
+//     without it the broker silently drops and still acks unroutable messages.
+//   - Every message is tagged with an OutcomeIDHeader header used for
+//     correlation; consumers of the message can see it.
+//   - When the channel is lost mid-flight, the outcome resolves with
+//     ErrOutcomeUnknown: the message may or may not have been delivered, so
+//     republishing can duplicate it.
+//   - WithPublisherOptionsMaxOutcomesInFlight bounds memory by blocking
+//     publishes until earlier outcomes resolve.
+//   - The underlying client notifies all basic.return listeners sequentially
+//     before processing further frames, so a slow handler registered with
+//     NotifyReturn on the same publisher delays outcome resolution (it cannot
+//     mis-pair outcomes, only delay them).
+//
+// On error, outcomes for routing keys already published are still returned
+// alongside the error, since those messages were sent.
+func (publisher *Publisher) PublishWithOutcome(
+	ctx context.Context,
+	data []byte,
+	routingKeys []string,
+	optionFuncs ...func(*PublishOptions),
+) ([]*PublishOutcome, error) {
+	if !publisher.options.ConfirmMode {
+		return nil, errors.New("PublishWithOutcome requires confirm mode: create the publisher with WithPublisherOptionsConfirm")
+	}
+	if publisher.disablePublishDueToFlow.Load() {
+		return nil, ErrPublishFlowPaused
+	}
+	if publisher.disablePublishDueToBlocked.Load() {
+		return nil, ErrPublishBlocked
+	}
+
+	publisher.outcomesOnce.Do(publisher.startOutcomeTracker)
+	tracker := publisher.outcomes
+
+	options := buildPublishOptions(optionFuncs)
+
+	var outcomes []*PublishOutcome
+	for _, routingKey := range routingKeys {
+		// wait until the returns listener covers the current channel; a
+		// publish racing ahead of it after a reconnect would have its
+		// basic.return delivered to no listener and report a false success
+		listenerGen, err := tracker.awaitCurrentListener(ctx)
+		if err != nil {
+			return outcomes, err
+		}
+		if err := tracker.acquire(ctx); err != nil {
+			return outcomes, err
+		}
+
+		id := tracker.nextID()
+		// buildPublishing copies the caller's headers into a fresh table, so
+		// adding the correlation header does not leak into caller state
+		message := buildPublishing(options, data)
+		message.Headers[OutcomeIDHeader] = id
+
+		gen := tracker.gen.Load()
+		conf, err := publisher.chanManager.PublishWithDeferredConfirmWithContextSafe(
+			ctx,
+			options.Exchange,
+			routingKey,
+			options.Mandatory,
+			options.Immediate,
+			message,
+		)
+		if err != nil {
+			tracker.release()
+			return outcomes, err
+		}
+		if conf == nil {
+			tracker.release()
+			return outcomes, errors.New("no deferred confirmation returned, channel is not in confirm mode")
+		}
+
+		// if a reconnect landed between the listener check and the publish,
+		// the message may have gone out on a channel the listener doesn't
+		// cover; resolve it conservatively rather than risk a false success
+		uncertain := tracker.chanManager.GetReconnectionCount() != listenerGen
+
+		po := &PublishOutcome{done: make(chan struct{})}
+		po.outcome.RoutingKey = routingKey
+		po.outcome.DeliveryTag = conf.DeliveryTag
+		tracker.outstanding.Add(1)
+		go tracker.await(&outcomeEntry{id: id, gen: gen, uncertain: uncertain, dc: conf, po: po})
+		outcomes = append(outcomes, po)
+	}
+	return outcomes, nil
+}
+
+func (publisher *Publisher) startOutcomeTracker() {
+	publisher.outcomes = newOutcomeTracker(
+		publisher.chanManager,
+		publisher.options.Logger,
+		publisher.done,
+		publisher.options.MaxOutcomesInFlight,
+	)
+	publisher.outcomes.start()
+}

--- a/publish_outcome.go
+++ b/publish_outcome.go
@@ -133,12 +133,38 @@ func (p *PublishOutcome) Ref() any {
 }
 
 // Wait blocks until the outcome is available or the context is done.
+//
+// On context expiry the returned Outcome still carries the message identity,
+// with Err set to the context error, so the message can be identified without
+// any caller-side bookkeeping. The message is genuinely still in flight in that
+// case: like ErrOutcomeUnknown it may yet be delivered, so only republish it if
+// consumers tolerate duplicates. Distinguish the two with errors.Is. The
+// outcome keeps resolving in the background, and Done and a later Wait still
+// report its true fate.
 func (p *PublishOutcome) Wait(ctx context.Context) (Outcome, error) {
 	select {
 	case <-p.done:
 		return p.outcome, nil
 	case <-ctx.Done():
-		return Outcome{}, ctx.Err()
+		// the context error goes on the returned copy only, never into
+		// p.outcome, so a later Wait still sees the real outcome
+		pending := p.identity()
+		pending.Err = ctx.Err()
+		return pending, ctx.Err()
+	}
+}
+
+// identity is the half of the outcome that is safe to read before it resolves:
+// these fields are written by PublishWithOutcome before the tracker goroutine
+// starts and the tracker never writes them, so reading them does not race with
+// a concurrent resolution. Do not widen this to Ack, Return or Err.
+func (p *PublishOutcome) identity() Outcome {
+	return Outcome{
+		ID:          p.outcome.ID,
+		Exchange:    p.outcome.Exchange,
+		RoutingKey:  p.outcome.RoutingKey,
+		DeliveryTag: p.outcome.DeliveryTag,
+		Ref:         p.outcome.Ref,
 	}
 }
 

--- a/publish_outcome.go
+++ b/publish_outcome.go
@@ -83,6 +83,10 @@ type Outcome struct {
 	// message only within one channel generation; use ID for an identity that
 	// is stable across reconnects.
 	DeliveryTag uint64
+	// Ref is the value passed to WithPublishOptionsOutcomeRef, or nil. Every
+	// outcome of one PublishWithOutcome call carries the same ref, so use
+	// RoutingKey to tell them apart.
+	Ref any
 	// Ack is true when the broker took responsibility for the message. Note
 	// that the broker acks mandatory messages it could not route (after
 	// sending the return), so a routing failure is Ack=true with a non-nil
@@ -119,6 +123,13 @@ type PublishOutcome struct {
 // Done returns a channel that is closed when the outcome is available.
 func (p *PublishOutcome) Done() <-chan struct{} {
 	return p.done
+}
+
+// Ref returns the value passed to WithPublishOptionsOutcomeRef, or nil. It is
+// fixed when the message is published, so unlike the rest of the Outcome it is
+// readable at any time, including while the outcome is still unresolved.
+func (p *PublishOutcome) Ref() any {
+	return p.outcome.Ref
 }
 
 // Wait blocks until the outcome is available or the context is done.
@@ -486,7 +497,9 @@ func (t *outcomeTracker) nextID() string {
 //     Outcome.ID so a publisher outcome can be matched against the delivery.
 //   - Each Outcome carries the ID, Exchange and RoutingKey of its message, so
 //     the failed subset of a batch says where each message belongs without a
-//     side table.
+//     side table. Use WithPublishOptionsOutcomeRef to attach your own value
+//     and get it back as Outcome.Ref, rather than keeping a parallel index
+//     from outcomes to the data they came from.
 //   - When the channel is lost mid-flight, the outcome resolves with
 //     ErrOutcomeUnknown: the message may or may not have been delivered, so
 //     republishing can duplicate it.
@@ -575,6 +588,7 @@ func (publisher *Publisher) PublishWithOutcome(
 		po.outcome.Exchange = options.Exchange
 		po.outcome.RoutingKey = routingKey
 		po.outcome.DeliveryTag = conf.DeliveryTag
+		po.outcome.Ref = options.OutcomeRef
 		tracker.outstanding.Add(1)
 		go tracker.await(&outcomeEntry{id: id, gen: gen, uncertain: uncertain, dc: conf, po: po})
 		outcomes = append(outcomes, po)

--- a/publish_outcome.go
+++ b/publish_outcome.go
@@ -15,6 +15,13 @@ import (
 // outcomeChannelManager is the subset of the channel manager the outcome
 // tracker relies on, extracted so the reconnect behavior can be tested
 // without a broker.
+//
+// Contract: GetReconnectionCount advances together with the channel swap,
+// while the channel lock is still held, so any operation that can reach the
+// new channel also observes the new count. The tracker's listener gate and
+// post-publish verification are unsound without this coupling — a publish
+// could land on a freshly swapped channel (with no returns listener yet)
+// while the count still reports the generation the listener covers.
 type outcomeChannelManager interface {
 	GetReconnectionCount() uint
 	NotifyReturnSafe(c chan amqp.Return) chan amqp.Return
@@ -36,7 +43,7 @@ const OutcomeIDHeader = "x-gorabbitmq-outcome-id"
 // races with a channel loss may occasionally be reported as unknown, but the
 // reverse never happens — an outcome reported as a definite ack or nack was
 // really sent by the broker on a live channel.
-var ErrOutcomeUnknown = errors.New("outcome unknown: channel closed before the broker confirmed the publishing")
+var ErrOutcomeUnknown = errors.New("outcome unknown: the channel was lost or replaced while the publishing was in flight")
 
 // ErrPublisherClosed reports that the publisher was closed before the
 // operation could complete.
@@ -209,12 +216,11 @@ func (t *outcomeTracker) start() {
 
 // registerReturnsListener installs a returns listener on the current channel
 // and records which reconnection generation it covers. The registration is
-// sandwiched between two reads of the reconnection count: when they agree,
-// the listener is installed on a channel no older than that generation (the
-// count advances only after a swap completes, so the listener can be on a
-// newer channel than recorded — which only makes the gate over-conservative,
-// never wrong). When the reads differ, it is unknown which channel the
-// listener landed on; it cannot simply be dropped, because the amqp client
+// sandwiched between two reads of the reconnection count: the count advances
+// atomically with the channel swap, so when the reads agree the listener is
+// installed on exactly that generation's channel — the count cannot lag a
+// swap the registration observed. When the reads differ, it is unknown which
+// channel the listener landed on; it cannot simply be dropped, because the amqp client
 // has no listener deregistration and an unconsumed listener on the live
 // channel would eventually fill and block the connection's frame dispatch.
 // It is drained and discarded instead: discarding is safe because publishes
@@ -287,10 +293,10 @@ func (t *outcomeTracker) run(returns <-chan amqp.Return, reconnCh <-chan error, 
 
 	for {
 		// wait for a reconnect signal while there is no live returns
-		// listener, or while the listener is stale — a registration that
-		// landed after a channel swap but before the reconnection count
-		// advanced records too old a generation, keeping the publish gate
-		// closed until re-registration
+		// listener, or while the listener is stale — a reconnect completed
+		// after the registration, so the pending signal should trigger
+		// re-registration promptly rather than waiting for the superseded
+		// listener's channel close to propagate
 		var reconn <-chan error
 		if (returns == nil || t.listenerStale()) && !doneSeen {
 			reconn = reconnCh
@@ -522,7 +528,10 @@ func (publisher *Publisher) PublishWithOutcome(
 
 		// if a reconnect landed between the listener check and the publish,
 		// the message may have gone out on a channel the listener doesn't
-		// cover; resolve it conservatively rather than risk a false success
+		// cover; resolve it conservatively rather than risk a false success.
+		// This check is sound because the count advances before a swapped-in
+		// channel becomes publishable: a publish that reached a newer channel
+		// than the listener's is always visible as a count mismatch here
 		uncertain := tracker.chanManager.GetReconnectionCount() != listenerGen
 
 		po := &PublishOutcome{done: make(chan struct{})}

--- a/publish_outcome.go
+++ b/publish_outcome.go
@@ -56,10 +56,32 @@ var ErrPublisherClosed = errors.New("publisher is closed")
 const bufferedReturnsCount = 64
 
 // Outcome is the final fate of one message published with PublishWithOutcome.
+//
+// The fields fall into two groups. The identity group describes which message
+// this is; it is filled in before the message is published and is never
+// rewritten, so it is populated on every Outcome a caller can observe. The
+// remaining fields are the message's fate, written once when the outcome
+// resolves. Exchange and RoutingKey are what PublishWithOutcome needs to send
+// the message again, so a failed Outcome says where it belongs without a side
+// table from futures back to destinations.
 type Outcome struct {
+	// ID is the correlation identity assigned to this publishing and put on
+	// the wire as the OutcomeIDHeader header, so a publisher outcome can be
+	// matched against the consumer-side delivery. It is unique per publishing
+	// and stable across reconnects, unlike DeliveryTag. It is not a logical
+	// message identity: republishing a message assigns a new ID. For an
+	// identity that survives a retry, set your own with
+	// WithPublishOptionsMessageID.
+	ID string
+	// Exchange the message was published to. The empty string is the default
+	// exchange.
+	Exchange string
 	// RoutingKey the message was published with.
 	RoutingKey string
-	// DeliveryTag the channel assigned to the publishing.
+	// DeliveryTag the channel assigned to the publishing. Delivery tags are
+	// per-channel and restart at 1 after a reconnect, so a tag identifies a
+	// message only within one channel generation; use ID for an identity that
+	// is stable across reconnects.
 	DeliveryTag uint64
 	// Ack is true when the broker took responsibility for the message. Note
 	// that the broker acks mandatory messages it could not route (after
@@ -85,7 +107,12 @@ func (o Outcome) Failed() bool {
 // PublishOutcome resolves to the Outcome of one published message once the
 // broker has confirmed or returned it, or the channel is lost.
 type PublishOutcome struct {
-	done    chan struct{}
+	done chan struct{}
+	// outcome is written in two disjoint halves. PublishWithOutcome fills in
+	// the identity fields before the tracker goroutine is started and never
+	// writes them again; the tracker writes only Ack, Return and Err, then
+	// closes done. Because the halves are distinct fields, reading the
+	// identity before done is closed does not race with the tracker.
 	outcome Outcome
 }
 
@@ -412,7 +439,7 @@ func (t *outcomeTracker) await(entry *outcomeEntry) {
 // goroutine. Without the stash there is no way to tell whether the message
 // was returned, so the outcome is conservatively unknown.
 func (t *outcomeTracker) abandon(entry *outcomeEntry) {
-	t.logger.Warnf("publisher closed with outcome still in flight, resolving delivery tag %d as unknown", entry.po.outcome.DeliveryTag)
+	t.logger.Warnf("publisher closed with outcome still in flight, resolving %s as unknown", entry.id)
 	entry.po.outcome.Err = ErrOutcomeUnknown
 	close(entry.po.done)
 	t.release()
@@ -455,7 +482,11 @@ func (t *outcomeTracker) nextID() string {
 //   - Detecting unroutable messages requires WithPublishOptionsMandatory;
 //     without it the broker silently drops and still acks unroutable messages.
 //   - Every message is tagged with an OutcomeIDHeader header used for
-//     correlation; consumers of the message can see it.
+//     correlation; consumers of the message can see it, and it is reported as
+//     Outcome.ID so a publisher outcome can be matched against the delivery.
+//   - Each Outcome carries the ID, Exchange and RoutingKey of its message, so
+//     the failed subset of a batch says where each message belongs without a
+//     side table.
 //   - When the channel is lost mid-flight, the outcome resolves with
 //     ErrOutcomeUnknown: the message may or may not have been delivered, so
 //     republishing can duplicate it.
@@ -466,7 +497,9 @@ func (t *outcomeTracker) nextID() string {
 //     NotifyReturn on the same publisher delays outcome resolution (it cannot
 //     mis-pair outcomes, only delay them).
 //
-// On error, outcomes for routing keys already published are still returned
+// The returned outcomes are in routing-key order, so on error the key whose
+// publish failed is routingKeys[len(outcomes)] and the keys after it were never
+// sent. Outcomes for routing keys already published are still returned
 // alongside the error, since those messages were sent.
 func (publisher *Publisher) PublishWithOutcome(
 	ctx context.Context,
@@ -535,6 +568,11 @@ func (publisher *Publisher) PublishWithOutcome(
 		uncertain := tracker.chanManager.GetReconnectionCount() != listenerGen
 
 		po := &PublishOutcome{done: make(chan struct{})}
+		// the identity half of the outcome is written before the tracker
+		// goroutine exists, so it is readable while the outcome is unresolved
+		// and is enough to place the message on a retry
+		po.outcome.ID = id
+		po.outcome.Exchange = options.Exchange
 		po.outcome.RoutingKey = routingKey
 		po.outcome.DeliveryTag = conf.DeliveryTag
 		tracker.outstanding.Add(1)

--- a/publish_outcome_test.go
+++ b/publish_outcome_test.go
@@ -1,0 +1,501 @@
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type fakeDC struct {
+	ack  bool
+	done chan struct{}
+}
+
+func (f *fakeDC) Done() <-chan struct{} { return f.done }
+
+func (f *fakeDC) Acked() bool {
+	select {
+	case <-f.done:
+		return f.ack
+	default:
+		return false
+	}
+}
+
+func resolvedDC(ack bool) *fakeDC {
+	f := &fakeDC{ack: ack, done: make(chan struct{})}
+	close(f.done)
+	return f
+}
+
+// newTestTracker runs a tracker against test-controlled channels instead of a
+// live amqp channel. Closing the returned stop func shuts the tracker down
+// and waits for its goroutine to exit.
+func newTestTracker(t *testing.T, maxInFlight int) (*outcomeTracker, chan amqp.Return, func()) {
+	t.Helper()
+	publisherDone := make(chan struct{})
+	fake := &fakeChanManager{reconnCh: make(chan error, 1)}
+	tracker := newOutcomeTracker(fake, stdDebugLogger{}, publisherDone, maxInFlight)
+	returns := make(chan amqp.Return, bufferedReturnsCount)
+	go tracker.run(returns, fake.reconnCh, make(chan struct{}, 1))
+	return tracker, returns, func() {
+		close(publisherDone)
+		select {
+		case <-tracker.exited:
+		case <-time.After(5 * time.Second):
+			t.Fatal("tracker did not exit")
+		}
+	}
+}
+
+// submit registers one in-flight publishing with the tracker the same way
+// PublishWithOutcome does.
+func submit(tracker *outcomeTracker, id string, dc deferredConfirmation) *PublishOutcome {
+	po := &PublishOutcome{done: make(chan struct{})}
+	po.outcome.RoutingKey = "test-key"
+	tracker.outstanding.Add(1)
+	go tracker.await(&outcomeEntry{id: id, gen: tracker.gen.Load(), dc: dc, po: po})
+	return po
+}
+
+func brokerReturn(id string) amqp.Return {
+	return amqp.Return{
+		ReplyCode:  312,
+		ReplyText:  "NO_ROUTE",
+		RoutingKey: "test-key",
+		Headers:    amqp.Table{OutcomeIDHeader: id},
+	}
+}
+
+func waitOutcome(t *testing.T, po *PublishOutcome) Outcome {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	outcome, err := po.Wait(ctx)
+	if err != nil {
+		t.Fatalf("timed out waiting for outcome: %v", err)
+	}
+	return outcome
+}
+
+// TestOutcomePairsReturnWithConfirmation loads both the return and the
+// resolved confirmation before the tracker can observe either, proving the
+// pairing does not depend on which channel the tracker's select happens to
+// pick first: the drain of the returns listener before resolving a
+// confirmation makes the stash authoritative.
+func TestOutcomePairsReturnWithConfirmation(t *testing.T) {
+	tracker, returns, stop := newTestTracker(t, 0)
+	defer stop()
+
+	returns <- brokerReturn(t.Name())
+	returned := submit(tracker, t.Name(), resolvedDC(true))
+	routed := submit(tracker, t.Name()+"-routed", resolvedDC(true))
+
+	outcome := waitOutcome(t, returned)
+	if !outcome.Ack || outcome.Return == nil || outcome.Err != nil {
+		t.Fatalf("expected acked outcome with return, got %+v", outcome)
+	}
+	if !outcome.Failed() {
+		t.Fatal("returned message must report Failed()")
+	}
+	if outcome.Return.ReplyCode != 312 {
+		t.Fatalf("wrong return paired: %+v", outcome.Return)
+	}
+
+	outcome = waitOutcome(t, routed)
+	if !outcome.Ack || outcome.Return != nil || outcome.Err != nil {
+		t.Fatalf("expected clean ack, got %+v", outcome)
+	}
+	if outcome.Failed() {
+		t.Fatal("acked unreturned message must not report Failed()")
+	}
+}
+
+// TestOutcomeGenuineNack verifies a broker nack on a live channel is reported
+// as a definite negative outcome, not an unknown one.
+func TestOutcomeGenuineNack(t *testing.T) {
+	tracker, _, stop := newTestTracker(t, 0)
+	defer stop()
+
+	outcome := waitOutcome(t, submit(tracker, t.Name(), resolvedDC(false)))
+	if outcome.Ack || outcome.Err != nil {
+		t.Fatalf("expected definite nack, got %+v", outcome)
+	}
+	if !outcome.Failed() {
+		t.Fatal("nacked message must report Failed()")
+	}
+}
+
+// TestOutcomeChannelLossResolvesUnknown simulates the amqp library's shutdown
+// sequence: the returns listener closes, then pending confirmations are
+// nacked. Those synthesized nacks must resolve as ErrOutcomeUnknown, not as
+// definite broker nacks.
+func TestOutcomeChannelLossResolvesUnknown(t *testing.T) {
+	tracker, returns, stop := newTestTracker(t, 0)
+	defer stop()
+
+	dc := &fakeDC{ack: false, done: make(chan struct{})}
+	po := submit(tracker, t.Name(), dc)
+
+	close(returns)
+	close(dc.done)
+
+	outcome := waitOutcome(t, po)
+	if !errors.Is(outcome.Err, ErrOutcomeUnknown) {
+		t.Fatalf("expected ErrOutcomeUnknown, got %+v", outcome)
+	}
+	if !outcome.Failed() {
+		t.Fatal("unknown outcome must report Failed()")
+	}
+}
+
+// TestOutcomeReturnSurvivesChannelLoss: when the return arrived but the
+// channel died before the confirmation, the outcome is unknown but still
+// carries the return as evidence the message was unroutable.
+func TestOutcomeReturnSurvivesChannelLoss(t *testing.T) {
+	tracker, returns, stop := newTestTracker(t, 0)
+	defer stop()
+
+	dc := &fakeDC{ack: false, done: make(chan struct{})}
+	po := submit(tracker, t.Name(), dc)
+
+	returns <- brokerReturn(t.Name())
+	close(returns)
+	close(dc.done)
+
+	outcome := waitOutcome(t, po)
+	if !errors.Is(outcome.Err, ErrOutcomeUnknown) || outcome.Return == nil {
+		t.Fatalf("expected unknown outcome with return attached, got %+v", outcome)
+	}
+}
+
+func TestOutcomeFailed(t *testing.T) {
+	ret := &Return{}
+	for _, test := range []struct {
+		name    string
+		outcome Outcome
+		failed  bool
+	}{
+		{"acked", Outcome{Ack: true}, false},
+		{"nacked", Outcome{Ack: false}, true},
+		{"acked but returned", Outcome{Ack: true, Return: ret}, true},
+		{"unknown", Outcome{Err: ErrOutcomeUnknown}, true},
+	} {
+		if got := test.outcome.Failed(); got != test.failed {
+			t.Errorf("%s: Failed() = %v, want %v", test.name, got, test.failed)
+		}
+	}
+}
+
+func TestOutcomeAcquireLimitAndCancellation(t *testing.T) {
+	publisherDone := make(chan struct{})
+	tracker := newOutcomeTracker(nil, stdDebugLogger{}, publisherDone, 1)
+
+	if err := tracker.acquire(context.Background()); err != nil {
+		t.Fatalf("first acquire should succeed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := tracker.acquire(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error while at capacity, got %v", err)
+	}
+
+	tracker.release()
+	if err := tracker.acquire(context.Background()); err != nil {
+		t.Fatalf("acquire after release should succeed: %v", err)
+	}
+
+	close(publisherDone)
+	if err := tracker.acquire(context.Background()); !errors.Is(err, ErrPublisherClosed) {
+		t.Fatalf("expected ErrPublisherClosed, got %v", err)
+	}
+}
+
+// TestOutcomeAfterTrackerExitResolvesUnknown pins down the close race: a
+// completion that can no longer reach the exited run goroutine must resolve
+// as unknown instead of stranding the waiter. This relies on completionCh
+// being unbuffered; with a buffer the send would succeed with no receiver
+// and the outcome would hang forever.
+func TestOutcomeAfterTrackerExitResolvesUnknown(t *testing.T) {
+	tracker, _, stop := newTestTracker(t, 0)
+	stop() // tracker has fully exited
+
+	outcome := waitOutcome(t, submit(tracker, t.Name(), resolvedDC(true)))
+	if !errors.Is(outcome.Err, ErrOutcomeUnknown) {
+		t.Fatalf("expected ErrOutcomeUnknown after tracker exit, got %+v", outcome)
+	}
+}
+
+// TestOutcomeCloseWithInFlight closes the publisher while confirmations are
+// still pending: the tracker must keep running until every outstanding
+// outcome resolves, then exit.
+func TestOutcomeCloseWithInFlight(t *testing.T) {
+	const inFlight = 20
+
+	publisherDone := make(chan struct{})
+	fake := &fakeChanManager{reconnCh: make(chan error, 1)}
+	tracker := newOutcomeTracker(fake, stdDebugLogger{}, publisherDone, 0)
+	returns := make(chan amqp.Return, bufferedReturnsCount)
+	go tracker.run(returns, fake.reconnCh, make(chan struct{}, 1))
+
+	var dcs []*fakeDC
+	var outcomes []*PublishOutcome
+	for i := range inFlight {
+		dc := &fakeDC{ack: false, done: make(chan struct{})}
+		dcs = append(dcs, dc)
+		outcomes = append(outcomes, submit(tracker, fmt.Sprintf("%s-%d", t.Name(), i), dc))
+	}
+
+	// publisher closes first, then the amqp library closes the returns
+	// listener and nacks the pending confirmations
+	close(publisherDone)
+	close(returns)
+	for _, dc := range dcs {
+		close(dc.done)
+	}
+
+	for i, po := range outcomes {
+		outcome := waitOutcome(t, po)
+		if !errors.Is(outcome.Err, ErrOutcomeUnknown) {
+			t.Fatalf("outcome %d: expected ErrOutcomeUnknown, got %+v", i, outcome)
+		}
+	}
+	select {
+	case <-tracker.exited:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tracker did not exit after all outcomes resolved")
+	}
+}
+
+// fakeChanManager simulates the channel manager's reconnect surface so the
+// listener-currency gate can be tested without a broker.
+type fakeChanManager struct {
+	count     atomic.Uint64
+	mu        sync.Mutex
+	listeners []chan amqp.Return
+	reconnCh  chan error
+	// onNotifyReturn, when set, runs during registration so tests can
+	// simulate a reconnect landing mid-registration.
+	onNotifyReturn func()
+}
+
+func (f *fakeChanManager) GetReconnectionCount() uint { return uint(f.count.Load()) }
+
+func (f *fakeChanManager) NotifyReturnSafe(c chan amqp.Return) chan amqp.Return {
+	f.mu.Lock()
+	f.listeners = append(f.listeners, c)
+	hook := f.onNotifyReturn
+	f.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+	return c
+}
+
+func (f *fakeChanManager) NotifyReconnect() (<-chan error, chan<- struct{}) {
+	return f.reconnCh, make(chan struct{}, 1)
+}
+
+func (f *fakeChanManager) listener(i int) chan amqp.Return {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listeners[i]
+}
+
+func (f *fakeChanManager) listenerCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.listeners)
+}
+
+// TestOutcomeListenerGateBlocksAcrossReconnect verifies publishes cannot race
+// ahead of the returns listener after a reconnect: awaitCurrentListener must
+// block from the moment the reconnection count advances until the tracker has
+// re-registered its listener on the new channel.
+func TestOutcomeListenerGateBlocksAcrossReconnect(t *testing.T) {
+	fake := &fakeChanManager{reconnCh: make(chan error, 1)}
+	publisherDone := make(chan struct{})
+	tracker := newOutcomeTracker(fake, stdDebugLogger{}, publisherDone, 0)
+	tracker.start()
+	defer func() {
+		close(publisherDone)
+		select {
+		case <-tracker.exited:
+		case <-time.After(5 * time.Second):
+			t.Fatal("tracker did not exit")
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// steady state: listener covers generation 0, no blocking
+	gen, err := tracker.awaitCurrentListener(ctx)
+	if err != nil || gen != 0 {
+		t.Fatalf("expected immediate pass at generation 0, got %d, %v", gen, err)
+	}
+
+	// broker connection swaps: count advances, old listener closes
+	fake.count.Store(1)
+	close(fake.listener(0))
+
+	gateResult := make(chan uint, 1)
+	go func() {
+		gen, err := tracker.awaitCurrentListener(ctx)
+		if err != nil {
+			t.Errorf("gate failed: %v", err)
+		}
+		gateResult <- gen
+	}()
+
+	select {
+	case gen := <-gateResult:
+		t.Fatalf("gate passed at generation %d before the listener was re-registered", gen)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// reconnect signal arrives: tracker re-registers and the gate opens
+	fake.reconnCh <- errors.New("reconnected")
+	select {
+	case gen := <-gateResult:
+		if gen != 1 {
+			t.Fatalf("gate passed for generation %d, want 1", gen)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("gate never opened after listener re-registration")
+	}
+	if got := fake.listenerCount(); got != 2 {
+		t.Fatalf("expected a second listener registration, got %d", got)
+	}
+}
+
+// TestOutcomeMismatchedRegistrationIsDrained simulates a reconnect landing in
+// the middle of listener registration: the superseded listener cannot be
+// deregistered from the amqp client, so it must be kept drained (a full,
+// unconsumed listener would block the connection's frame dispatch), and the
+// retry must land on the new generation.
+func TestOutcomeMismatchedRegistrationIsDrained(t *testing.T) {
+	fake := &fakeChanManager{reconnCh: make(chan error, 1)}
+	var once sync.Once
+	fake.onNotifyReturn = func() {
+		once.Do(func() { fake.count.Store(1) })
+	}
+	publisherDone := make(chan struct{})
+	tracker := newOutcomeTracker(fake, stdDebugLogger{}, publisherDone, 0)
+	tracker.start()
+	defer func() {
+		close(publisherDone)
+		select {
+		case <-tracker.exited:
+		case <-time.After(5 * time.Second):
+			t.Fatal("tracker did not exit")
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	gen, err := tracker.awaitCurrentListener(ctx)
+	if err != nil || gen != 1 {
+		t.Fatalf("expected retried registration at generation 1, got %d, %v", gen, err)
+	}
+	if got := fake.listenerCount(); got != 2 {
+		t.Fatalf("expected mismatched + retried registrations, got %d", got)
+	}
+
+	// overfill the superseded listener's buffer: if it were not drained,
+	// these sends (like the client's dispatch goroutine) would block forever
+	zombie := fake.listener(0)
+	defer close(zombie)
+	for i := 0; i < 2*bufferedReturnsCount; i++ {
+		select {
+		case zombie <- amqp.Return{}:
+		case <-time.After(5 * time.Second):
+			t.Fatal("superseded listener is not being drained")
+		}
+	}
+}
+
+// TestOutcomeUncertainPublishResolvesConservatively covers the residual race
+// where a reconnect lands between the listener check and the publish: a bare
+// ack proves nothing (the return may have gone to no listener) and must
+// resolve as unknown, while a present return stays definitive.
+func TestOutcomeUncertainPublishResolvesConservatively(t *testing.T) {
+	tracker, returns, stop := newTestTracker(t, 0)
+	defer stop()
+
+	submitUncertain := func(id string) *PublishOutcome {
+		po := &PublishOutcome{done: make(chan struct{})}
+		tracker.outstanding.Add(1)
+		go tracker.await(&outcomeEntry{
+			id: id, gen: tracker.gen.Load(), uncertain: true, dc: resolvedDC(true), po: po,
+		})
+		return po
+	}
+
+	outcome := waitOutcome(t, submitUncertain(t.Name()+"-bare-ack"))
+	if !outcome.Ack || !errors.Is(outcome.Err, ErrOutcomeUnknown) {
+		t.Fatalf("uncertain bare ack must resolve unknown, got %+v", outcome)
+	}
+
+	returns <- brokerReturn(t.Name() + "-returned")
+	outcome = waitOutcome(t, submitUncertain(t.Name()+"-returned"))
+	if !outcome.Ack || outcome.Return == nil || outcome.Err != nil {
+		t.Fatalf("uncertain ack with return is definitive, got %+v", outcome)
+	}
+}
+
+// TestOutcomeManyInFlight drives many concurrent publishings with a small
+// in-flight cap and randomized return/confirm interleaving, asserting the
+// failed set is reconstructed exactly. Run with -race.
+func TestOutcomeManyInFlight(t *testing.T) {
+	const messageCount = 500
+
+	tracker, returns, stop := newTestTracker(t, 8)
+	defer stop()
+
+	wantFailed := map[string]bool{}
+	outcomes := map[string]*PublishOutcome{}
+
+	var wg sync.WaitGroup
+	for i := range messageCount {
+		id := fmt.Sprintf("msg-%d", i)
+		unroutable := i%7 == 0
+		wantFailed[id] = unroutable
+
+		if err := tracker.acquire(context.Background()); err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+		dc := &fakeDC{ack: true, done: make(chan struct{})}
+		outcomes[id] = submit(tracker, id, dc)
+
+		wg.Add(1)
+		go func(id string, unroutable bool, dc *fakeDC) {
+			defer wg.Done()
+			time.Sleep(time.Duration(rand.Intn(3)) * time.Millisecond)
+			if unroutable {
+				// the broker sends the return strictly before the confirmation
+				returns <- brokerReturn(id)
+			}
+			close(dc.done)
+		}(id, unroutable, dc)
+	}
+	wg.Wait()
+
+	for id, po := range outcomes {
+		outcome := waitOutcome(t, po)
+		if outcome.Err != nil {
+			t.Fatalf("%s: unexpected error %v", id, outcome.Err)
+		}
+		if got, want := outcome.Failed(), wantFailed[id]; got != want {
+			t.Fatalf("%s: Failed() = %v, want %v (outcome %+v)", id, got, want, outcome)
+		}
+	}
+}

--- a/publish_outcome_test.go
+++ b/publish_outcome_test.go
@@ -55,13 +55,19 @@ func newTestTracker(t *testing.T, maxInFlight int) (*outcomeTracker, chan amqp.R
 	}
 }
 
+// testRef stands in for a caller's own value attached with
+// WithPublishOptionsOutcomeRef. It is a distinct type from the library's id so
+// a test cannot pass by accidentally comparing the ref against Outcome.ID.
+type testRef struct{ name string }
+
 // submit registers one in-flight publishing with the tracker the same way
-// PublishWithOutcome does.
+// PublishWithOutcome does, including the identity fields.
 func submit(tracker *outcomeTracker, id string, dc deferredConfirmation) *PublishOutcome {
 	po := &PublishOutcome{done: make(chan struct{})}
 	po.outcome.ID = id
 	po.outcome.Exchange = "test-exchange"
 	po.outcome.RoutingKey = "test-key"
+	po.outcome.Ref = &testRef{name: id}
 	tracker.outstanding.Add(1)
 	go tracker.await(&outcomeEntry{id: id, gen: tracker.gen.Load(), dc: dc, po: po})
 	return po
@@ -176,6 +182,140 @@ func TestOutcomeReturnSurvivesChannelLoss(t *testing.T) {
 	if !errors.Is(outcome.Err, ErrOutcomeUnknown) || outcome.Return == nil {
 		t.Fatalf("expected unknown outcome with return attached, got %+v", outcome)
 	}
+}
+
+// TestOutcomeRefStaysOffTheWire: the ref is caller-side state, so unlike
+// CorrelationID it must not reach the broker in any form. buildPublishing
+// enumerates AMQP fields explicitly, and this pins that down so adding a
+// pass-through there cannot leak a caller's struct onto the wire.
+func TestOutcomeRefStaysOffTheWire(t *testing.T) {
+	secret := &testRef{name: "must-not-be-published"}
+	options := buildPublishOptions([]func(*PublishOptions){
+		WithPublishOptionsOutcomeRef(secret),
+		WithPublishOptionsHeaders(Table{"keep": "me"}),
+	})
+	if options.OutcomeRef != secret {
+		t.Fatal("WithPublishOptionsOutcomeRef did not set OutcomeRef")
+	}
+
+	message := buildPublishing(options, []byte("body"))
+	for key, value := range message.Headers {
+		if value == secret || value == any(secret) {
+			t.Errorf("header %q carries the outcome ref", key)
+		}
+	}
+	if _, ok := message.Headers["OutcomeRef"]; ok {
+		t.Error("OutcomeRef leaked into the message headers")
+	}
+	if message.CorrelationId != "" || message.MessageId != "" || message.AppId != "" {
+		t.Errorf("ref leaked into an AMQP property: %+v", message)
+	}
+	if got := message.Headers["keep"]; got != "me" {
+		t.Errorf("caller headers were not preserved: %v", got)
+	}
+}
+
+// TestOutcomeIdentitySurvivesEveryResolution asserts the identity half of an
+// Outcome is intact no matter which path resolved it. The tracker writes only
+// Ack, Return and Err, and this is the guard against a future rewrite that
+// assigns po.outcome wholesale and silently drops the caller's ref.
+func TestOutcomeIdentitySurvivesEveryResolution(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		resolve func(t *testing.T, tracker *outcomeTracker, returns chan amqp.Return, id string) *PublishOutcome
+	}{
+		{"acked", func(_ *testing.T, tracker *outcomeTracker, _ chan amqp.Return, id string) *PublishOutcome {
+			return submit(tracker, id, resolvedDC(true))
+		}},
+		{"returned and acked", func(_ *testing.T, tracker *outcomeTracker, returns chan amqp.Return, id string) *PublishOutcome {
+			returns <- brokerReturn(id)
+			return submit(tracker, id, resolvedDC(true))
+		}},
+		{"genuine nack", func(_ *testing.T, tracker *outcomeTracker, _ chan amqp.Return, id string) *PublishOutcome {
+			return submit(tracker, id, resolvedDC(false))
+		}},
+		{"channel loss", func(_ *testing.T, tracker *outcomeTracker, returns chan amqp.Return, id string) *PublishOutcome {
+			dc := &fakeDC{ack: false, done: make(chan struct{})}
+			po := submit(tracker, id, dc)
+			close(returns)
+			close(dc.done)
+			return po
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tracker, returns, stop := newTestTracker(t, 0)
+			defer stop()
+
+			id := t.Name()
+			outcome := waitOutcome(t, test.resolve(t, tracker, returns, id))
+			assertIdentity(t, outcome, id)
+		})
+	}
+
+	// abandon resolves entries whose completion can no longer reach the run
+	// goroutine, and it is the one path that does not go through resolve
+	t.Run("abandoned after tracker exit", func(t *testing.T) {
+		tracker, _, stop := newTestTracker(t, 0)
+		stop()
+
+		id := t.Name()
+		outcome := waitOutcome(t, submit(tracker, id, resolvedDC(true)))
+		assertIdentity(t, outcome, id)
+	})
+}
+
+func assertIdentity(t *testing.T, outcome Outcome, id string) {
+	t.Helper()
+	if outcome.ID != id {
+		t.Errorf("ID = %q, want %q", outcome.ID, id)
+	}
+	if outcome.Exchange != "test-exchange" {
+		t.Errorf("Exchange = %q, want %q", outcome.Exchange, "test-exchange")
+	}
+	if outcome.RoutingKey != "test-key" {
+		t.Errorf("RoutingKey = %q, want %q", outcome.RoutingKey, "test-key")
+	}
+	ref, ok := outcome.Ref.(*testRef)
+	if !ok {
+		t.Fatalf("Ref = %#v, want a *testRef", outcome.Ref)
+	}
+	if ref.name != id {
+		t.Errorf("Ref.name = %q, want %q", ref.name, id)
+	}
+}
+
+// TestOutcomeRefReadableWhileUnresolved is the executable form of the
+// disjointness argument: the ref is written before the tracker goroutine
+// starts and the tracker never touches it, so reading it concurrently with
+// resolution is not a race. Only meaningful under -race.
+func TestOutcomeRefReadableWhileUnresolved(t *testing.T) {
+	tracker, _, stop := newTestTracker(t, 0)
+	defer stop()
+
+	const messages = 50
+	var wg sync.WaitGroup
+	for i := range messages {
+		id := fmt.Sprintf("%s-%d", t.Name(), i)
+		dc := &fakeDC{ack: true, done: make(chan struct{})}
+		po := submit(tracker, id, dc)
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// read the ref while the tracker is resolving the same outcome
+			for range 100 {
+				if ref := po.Ref().(*testRef); ref.name != id {
+					t.Errorf("Ref.name = %q, want %q", ref.name, id)
+					return
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			close(dc.done)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestOutcomeFailed(t *testing.T) {
@@ -438,6 +578,7 @@ func TestOutcomeUncertainPublishResolvesConservatively(t *testing.T) {
 		po.outcome.ID = id
 		po.outcome.Exchange = "test-exchange"
 		po.outcome.RoutingKey = "test-key"
+		po.outcome.Ref = &testRef{name: id}
 		tracker.outstanding.Add(1)
 		go tracker.await(&outcomeEntry{
 			id: id, gen: tracker.gen.Load(), uncertain: true, dc: resolvedDC(true), po: po,

--- a/publish_outcome_test.go
+++ b/publish_outcome_test.go
@@ -284,6 +284,46 @@ func assertIdentity(t *testing.T, outcome Outcome, id string) {
 	}
 }
 
+// TestOutcomeWaitTimeoutKeepsIdentity: giving up on an unresolved outcome is
+// exactly when a caller needs to know which message it gave up on, so the
+// timeout path returns the identity rather than a zero Outcome. The context
+// error must not be written into the outcome itself: a later Wait still has to
+// report the message's real fate.
+func TestOutcomeWaitTimeoutKeepsIdentity(t *testing.T) {
+	tracker, _, stop := newTestTracker(t, 0)
+	defer stop()
+
+	id := t.Name()
+	dc := &fakeDC{ack: true, done: make(chan struct{})}
+	po := submit(tracker, id, dc)
+
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	outcome, err := po.Wait(expired)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if !errors.Is(outcome.Err, context.Canceled) {
+		t.Errorf("outcome.Err = %v, want context.Canceled", outcome.Err)
+	}
+	if !outcome.Failed() {
+		t.Error("an outcome still in flight must report Failed()")
+	}
+	if outcome.Ack || outcome.Return != nil {
+		t.Errorf("timeout must not report a fate, got %+v", outcome)
+	}
+	assertIdentity(t, outcome, id)
+
+	// the real outcome is unaffected by having been waited on and abandoned
+	close(dc.done)
+	resolved := waitOutcome(t, po)
+	if !resolved.Ack || resolved.Err != nil {
+		t.Fatalf("resolved outcome = %+v, want acked with no error", resolved)
+	}
+	assertIdentity(t, resolved, id)
+}
+
 // TestOutcomeRefReadableWhileUnresolved is the executable form of the
 // disjointness argument: the ref is written before the tracker goroutine
 // starts and the tracker never touches it, so reading it concurrently with
@@ -329,6 +369,7 @@ func TestOutcomeFailed(t *testing.T) {
 		{"nacked", Outcome{Ack: false}, true},
 		{"acked but returned", Outcome{Ack: true, Return: ret}, true},
 		{"unknown", Outcome{Err: ErrOutcomeUnknown}, true},
+		{"still in flight", Outcome{Err: context.DeadlineExceeded}, true},
 	} {
 		if got := test.outcome.Failed(); got != test.failed {
 			t.Errorf("%s: Failed() = %v, want %v", test.name, got, test.failed)

--- a/publish_outcome_test.go
+++ b/publish_outcome_test.go
@@ -59,6 +59,8 @@ func newTestTracker(t *testing.T, maxInFlight int) (*outcomeTracker, chan amqp.R
 // PublishWithOutcome does.
 func submit(tracker *outcomeTracker, id string, dc deferredConfirmation) *PublishOutcome {
 	po := &PublishOutcome{done: make(chan struct{})}
+	po.outcome.ID = id
+	po.outcome.Exchange = "test-exchange"
 	po.outcome.RoutingKey = "test-key"
 	tracker.outstanding.Add(1)
 	go tracker.await(&outcomeEntry{id: id, gen: tracker.gen.Load(), dc: dc, po: po})
@@ -433,6 +435,9 @@ func TestOutcomeUncertainPublishResolvesConservatively(t *testing.T) {
 
 	submitUncertain := func(id string) *PublishOutcome {
 		po := &PublishOutcome{done: make(chan struct{})}
+		po.outcome.ID = id
+		po.outcome.Exchange = "test-exchange"
+		po.outcome.RoutingKey = "test-key"
 		tracker.outstanding.Add(1)
 		go tracker.await(&outcomeEntry{
 			id: id, gen: tracker.gen.Load(), uncertain: true, dc: resolvedDC(true), po: po,

--- a/publisher_options.go
+++ b/publisher_options.go
@@ -8,6 +8,9 @@ type PublisherOptions struct {
 	ExchangeOptions ExchangeOptions
 	Logger          Logger
 	ConfirmMode     bool
+	// MaxOutcomesInFlight caps how many PublishWithOutcome publishings may be
+	// awaiting their outcome at once; 0 means unlimited.
+	MaxOutcomesInFlight int
 }
 
 // getDefaultPublisherOptions describes the options that will be used when a value isn't provided
@@ -106,4 +109,14 @@ func WithPublisherOptionsExchangeArgs(args Table) func(*PublisherOptions) {
 // this is required if publisher confirmations should be used
 func WithPublisherOptionsConfirm(options *PublisherOptions) {
 	options.ConfirmMode = true
+}
+
+// WithPublisherOptionsMaxOutcomesInFlight caps how many PublishWithOutcome
+// publishings may be awaiting their outcome at once. Further publishes block
+// until earlier outcomes resolve, bounding the memory the publisher can
+// accumulate when the broker confirms slower than the application publishes.
+func WithPublisherOptionsMaxOutcomesInFlight(max int) func(*PublisherOptions) {
+	return func(options *PublisherOptions) {
+		options.MaxOutcomesInFlight = max
+	}
 }


### PR DESCRIPTION
This is a reimplementation of #204. Thanks to @wagslane for identifying the race conditions in the previous approach. I should have examined them more closely.

## Overview

Reliable publishing is possible because the `amqp091-go` client preserves the ordering between `basic.return` and `basic.ack`. A detailed analysis of the relevant guarantees is available here:

https://htmlbin.dev/p/ghm42kxqC/raw#guarantees

Correctly pairing publish outcomes becomes more complicated when accounting for reconnections, multiple acknowledgements, sequence-number changes, and channels closing while messages are still in flight.

This PR introduces `PublishWithOutcome()`, which allows users to track the outcome of each individual publish.

```go
outcomes, err := publisher.PublishWithOutcome(
	ctx,
	[]byte("hello, world"),
	[]string{"my_routing_key"},
	rabbitmq.WithPublishOptionsExchange("events"),
	rabbitmq.WithPublishOptionsMandatory, // required to detect unroutable messages
)
if err != nil {
	log.Println(err)
}

for _, po := range outcomes {
	outcome, err := po.Wait(ctx)
	if err != nil {
		log.Println(err)
	} else if outcome.Failed() {
		// The message was nacked, returned as unroutable, or its outcome
		// became unknown because the channel was lost while it was in flight.
		//
		// The message may be republished, but see ErrOutcomeUnknown for
		// information about the possibility of duplicate delivery.
	}
}
```

### Correlating outcomes with application data

`WithPublishOptionsOutcomeRef()` allows users to associate an arbitrary value with a publish. That value is returned as part of the outcome, making it easier to correlate failures with the original application data and implement at-least-once delivery.

```go
outcomes, err := publisher.PublishWithOutcome(
	ctx,
	row.Body,
	[]string{row.RoutingKey},
	rabbitmq.WithPublishOptionsMandatory,
	rabbitmq.WithPublishOptionsOutcomeRef(row), // echoed back in the outcome
)
if err != nil {
	log.Println(err)
}

for _, po := range outcomes {
	outcome, err := po.Wait(ctx)
	if err != nil {
		log.Println(err)
		continue
	}

	if outcome.Failed() {
		row := outcome.Ref.(*Row)

		// Republish the row, or record the failure in your database.
		log.Printf("row %d failed: %v", row.ID, outcome.Err)
	}
}
```

## Performance

In a local benchmark against RabbitMQ 4.1.1 using 25-byte payloads, outcome tracking added approximately:

* 3.0 µs per message
* 1.13 KB of memory per message
* 20 allocations per message

Compared with the library’s existing publisher-confirm API, throughput was approximately 23% lower. Given the additional per-message outcome tracking and correlation guarantees, this seems like an acceptable trade-off.

## Design documentation

The detailed design, including the ordering guarantees and handling of reconnections, acknowledgements, returns, and unknown outcomes, is documented here:

https://htmlbin.dev/p/ghm42kxqC/raw

The initial `PublishWithOutcome()` implementation and the later `WithPublishOptionsOutcomeRef()` addition were implemented with Claude Code Fable 5 and Claude Code Opus 5. The design document was also AI-generated, but I believe it explains the approach and its trade-offs fairly well.

Please have a look and let me know what you think. Thanks @wagslane 

Update: I've asked Claude Code to rewrite the design doc based on [ASD-STE100](https://www.asd-ste100.org/). Here's the more "human" version: https://htmlbin.dev/p/I4K93eJ3z/raw 
